### PR TITLE
fix/cargo-doc Add recursion limit to allow cargo documentation to build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![doc = include_str!("../README.md")]
 
 pub mod berries;


### PR DESCRIPTION
Closes issue #9 