### PR TITLE
Fix "async_follow" example

### DIFF
--- a/examples/async_follow.rs
+++ b/examples/async_follow.rs
@@ -11,6 +11,7 @@ async fn main() {
     let evolution_chain = species
         .unwrap()
         .evolution_chain
+        .unwrap()
         .follow(&rustemon_client)
         .await;
     println!("{:#?}", evolution_chain);


### PR DESCRIPTION
This example broke because of [this commit](https://github.com/mlemesle/rustemon/commit/7df0c2539f9b3c4be529b99785c37fdbe6881fd8).