### PR TITLE
Add "get_all_pages" function to all endpoints

### DIFF
--- a/examples/get_all_type_names.rs
+++ b/examples/get_all_type_names.rs
@@ -2,27 +2,10 @@
 async fn main() {
     // Gets the names of all pokmon types. Retrieving them 5 by 5 from the api.
     let rustemon_client = rustemon::client::RustemonClient::default();
-    let mut offset = 0;
-    let limit = 5;
-    let number_of_type = rustemon::pokemon::type_::get_page(&rustemon_client)
+    let types = rustemon::pokemon::type_::get_all_pages(&rustemon_client)
         .await
-        .unwrap()
-        .count;
-    let mut type_names: Vec<String> = vec![];
-    while offset < number_of_type {
-        match rustemon::pokemon::type_::get_page_with_param(offset, limit, &rustemon_client).await {
-            Ok(page) => {
-                for name in page.results {
-                    type_names.push(name.name);
-                }
-                offset += limit;
-            }
-            Err(err) => {
-                println!("Error occured : {}", err);
-                break;
-            }
-        }
-    }
+        .unwrap();
+    let type_names: Vec<String> = types.into_iter().map(|type_| type_.name).collect();
 
     println!("All Pokémon type names : {:#?}", type_names);
 }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -44,21 +44,16 @@ macro_rules! endpoint {
         ///
         /// `rustemon_client` - The [RustemonClient] to use to access the resource.
         pub async fn get_all_pages(rustemon_client: &RustemonClient) -> Result<Vec<NamedApiResource<$type>>, Error> {
-            const LIMIT: i64 = 100;
+            let url = Url::parse(ENDPOINT).unwrap();
 
-            let mut page = get_page_with_param(0, LIMIT, rustemon_client).await?;
-
+            let mut page = rustemon_client.get_by_url::<NamedApiResourceList<$type>>(url).await?;
             let mut all_pages = Vec::with_capacity(page.count as usize);
-            let page_count =  {
-                let remaining_pages = (page.count as f32) / (LIMIT as f32);
-                remaining_pages.ceil() as i64
-            };
 
             all_pages.append(&mut page.results);
 
-            for page_number in 1..page_count {
-                let offset = page_number * LIMIT;
-                let mut page = get_page_with_param(offset, LIMIT, rustemon_client).await?;
+            while let Some(ref next_page_url) = page.next {
+                let next_page_url = Url::parse(next_page_url).unwrap();
+                page = rustemon_client.get_by_url::<NamedApiResourceList<$type>>(next_page_url).await?;
 
                 all_pages.append(&mut page.results);
             }


### PR DESCRIPTION
This is a more convenient way to get all of the resources from a given endpoint.