### PR TITLE
add Serialize to internal structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "3.4.1"
 default = ["filesystem-cache"]
 filesystem-cache = ["http-cache-reqwest/manager-cacache"]
 in-memory-cache = ["http-cache-reqwest/manager-moka"]
+serialize = []
 
 [dependencies]
 async-trait = "0.1.80"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ If you want to use the `in-memory-cache` feature, you can proceed as follow:
 rustemon = { version = "*", default-features = false, features = ["in-memory-cache"] } 
 ```
 
+Also, to support easier export to other tooling and libraries, the `serialize` feature enables PokeApi structs to be compiled with `serde::Serialize`.
+This feature is disabled by default.
+
 ##### Models
 
 All the models are located into the following module :

--- a/src/model/berries.rs
+++ b/src/model/berries.rs
@@ -9,6 +9,7 @@ use super::{
 
 /// [Berry official documentation](https:///pokeapi.co/docs/v2#berry)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Berry {
     /// The identifier for this resource.
     pub id: i64,
@@ -41,6 +42,7 @@ pub struct Berry {
 
 /// [BerryFlavorMap official documentation](https:///pokeapi.co/docs/v2#berryflavormap)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct BerryFlavorMap {
     /// How powerful the referenced flavor is for this berry.
     pub potency: i64,
@@ -50,6 +52,7 @@ pub struct BerryFlavorMap {
 
 /// [BerryFirmness official documentation](https:///pokeapi.co/docs/v2#berryfirmness)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct BerryFirmness {
     /// The identifier for this resource.
     pub id: i64,
@@ -63,6 +66,7 @@ pub struct BerryFirmness {
 
 /// [BerryFlavor official documentation](https:///pokeapi.co/docs/v2#berryflavor)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct BerryFlavor {
     /// The identifier for this resource.
     pub id: i64,
@@ -78,6 +82,7 @@ pub struct BerryFlavor {
 
 /// [FlavorBerryMap official documentation](https:///pokeapi.co/docs/v2#flavorberrymap)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct FlavorBerryMap {
     /// How powerful the referenced flavor is for this berry.
     pub potency: i64,

--- a/src/model/contests.rs
+++ b/src/model/contests.rs
@@ -9,6 +9,7 @@ use super::{
 
 /// [ContestType official documentation] (https:///pokeapi.co/docs/v2#contesttype)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ContestType {
     /// The identifier for this resource.
     pub id: i64,
@@ -22,6 +23,7 @@ pub struct ContestType {
 
 /// [ContestName official documentation](https:///pokeapi.co/docs/v2#contestname)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ContestName {
     /// The name for this contest.
     pub name: Option<String>,
@@ -33,6 +35,7 @@ pub struct ContestName {
 
 /// [ContestEffect official documentation](https:///pokeapi.co/docs/v2#contesteffect)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ContestEffect {
     /// The identifier for this resource.
     pub id: i64,
@@ -48,6 +51,7 @@ pub struct ContestEffect {
 
 /// [SuperContestEffect official documentation](https:///pokeapi.co/docs/v2#supercontesteffect)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct SuperContestEffect {
     /// The identifier for this resource.
     pub id: i64,

--- a/src/model/encounters.rs
+++ b/src/model/encounters.rs
@@ -4,6 +4,7 @@ use super::resource::{Name, NamedApiResource};
 
 /// [EncounterMethod official documentation](https:///pokeapi.co/docs/v2#encountermethod)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EncounterMethod {
     /// The identifier for this resource.
     pub id: i64,
@@ -17,6 +18,7 @@ pub struct EncounterMethod {
 
 /// [EncounterCondition official documentation](https:///pokeapi.co/docs/v2#encountercondition)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EncounterCondition {
     /// The identifier for this resource.
     pub id: i64,
@@ -30,6 +32,7 @@ pub struct EncounterCondition {
 
 /// [EncounterConditionValue](https:///pokeapi.co/docs/v2#encounterconditionvalue)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EncounterConditionValue {
     /// The identifier for this resource.
     pub id: i64,

--- a/src/model/evolution.rs
+++ b/src/model/evolution.rs
@@ -10,6 +10,7 @@ use super::{
 
 /// [EvolutionChain official documentation](https:///pokeapi.co/docs/v2#evolutionchain)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EvolutionChain {
     /// The identifier for this resource.
     pub id: i64,
@@ -23,6 +24,7 @@ pub struct EvolutionChain {
 
 /// [ChainLink official documentation](https:///pokeapi.co/docs/v2#chainlink)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ChainLink {
     /// Whether or not this link is for a baby Pokémon. This would only ever be true on the base link.
     pub is_baby: bool,
@@ -36,6 +38,7 @@ pub struct ChainLink {
 
 /// [EvolutionDetail official documentation](https:///pokeapi.co/docs/v2#evolutiondetail)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EvolutionDetail {
     /// The item required to cause evolution this into Pokémon species.
     pub item: Option<NamedApiResource<Item>>,
@@ -83,6 +86,7 @@ pub struct EvolutionDetail {
 
 /// [EvolutionTrigger official documentation](https:///pokeapi.co/docs/v2#evolutiontrigger)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EvolutionTrigger {
     /// The identifier for this resource.
     pub id: i64,

--- a/src/model/games.rs
+++ b/src/model/games.rs
@@ -9,6 +9,7 @@ use super::{
 
 /// [Generation official documentation]
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Generation {
     /// The identifier for this resource.
     pub id: i64,
@@ -32,6 +33,7 @@ pub struct Generation {
 
 /// [Pokedex official documentation](https:///pokeapi.co/docs/v2#pokedex)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Pokedex {
     /// The identifier for this resource.
     pub id: i64,
@@ -53,6 +55,7 @@ pub struct Pokedex {
 
 /// [PokemonEntry official documentation](https:///pokeapi.co/docs/v2#pokemonentry)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonEntry {
     /// The index of this Pokémon species entry within the Pokédex.
     pub entry_number: i64,
@@ -62,6 +65,7 @@ pub struct PokemonEntry {
 
 /// [Version offcial documentation](https:///pokeapi.co/docs/v2#version)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Version {
     /// The identifier for this resource.
     pub id: i64,
@@ -75,6 +79,7 @@ pub struct Version {
 
 /// [VersionGroup official documentation](https:///pokeapi.co/docs/v2#versiongroup)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct VersionGroup {
     /// The identifier for this resource.
     pub id: i64,

--- a/src/model/items.rs
+++ b/src/model/items.rs
@@ -12,6 +12,7 @@ use super::{
 
 /// [Item official documentation](https://pokeapi.co/docs/v2#item)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Item {
     /// The identifier for this resource.
     pub id: i64,
@@ -47,6 +48,7 @@ pub struct Item {
 
 /// [ItemSprites official documentation](https://pokeapi.co/docs/v2#itemsprites)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ItemSprites {
     /// The default depiction of this item.
     pub default: Option<String>,
@@ -54,6 +56,7 @@ pub struct ItemSprites {
 
 /// [ItemHolderPokemon official documentation](https://pokeapi.co/docs/v2#itemholderpokemon)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ItemHolderPokemon {
     /// The Pokémon that holds this item.
     pub pokemon: NamedApiResource<Pokemon>,
@@ -63,6 +66,7 @@ pub struct ItemHolderPokemon {
 
 /// [ItemHolderPokemonVersionDetail official documentation](https://pokeapi.co/docs/v2#itemholderpokemonversiondetail)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ItemHolderPokemonVersionDetail {
     /// How often this Pokémon holds this item in this version.
     pub rarity: i64,
@@ -72,6 +76,7 @@ pub struct ItemHolderPokemonVersionDetail {
 
 /// [ItemAttribute official documentation](https://pokeapi.co/docs/v2#itemattribute)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ItemAttribute {
     /// The identifier for this resource.
     pub id: i64,
@@ -87,6 +92,7 @@ pub struct ItemAttribute {
 
 /// [ItemCategory official documentation](https://pokeapi.co/docs/v2#itemcategory)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ItemCategory {
     /// The identifier for this resource.
     pub id: i64,
@@ -102,6 +108,7 @@ pub struct ItemCategory {
 
 /// [ItemFlingEffect official documentation](https://pokeapi.co/docs/v2#itemflingeffect)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ItemFlingEffect {
     /// The identifier for this resource.
     pub id: i64,
@@ -115,6 +122,7 @@ pub struct ItemFlingEffect {
 
 /// [ItemPocket official documentation](https://pokeapi.co/docs/v2#itempocket)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ItemPocket {
     /// The identifier for this resource.
     pub id: i64,

--- a/src/model/locations.rs
+++ b/src/model/locations.rs
@@ -9,6 +9,7 @@ use super::{
 
 /// [Location official documentation](https://pokeapi.co/docs/v2#location)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Location {
     /// The identifier for this resource.
     pub id: i64,
@@ -26,6 +27,7 @@ pub struct Location {
 
 /// [LocationArea official documentation](https://pokeapi.co/docs/v2#locationarea)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct LocationArea {
     /// The identifier for this resource.
     pub id: i64,
@@ -47,6 +49,7 @@ pub struct LocationArea {
 
 /// [EncounterMethodRate official documentation](https://pokeapi.co/docs/v2#encountermethodrate)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EncounterMethodRate {
     /// The method in which Pokémon may be encountered in an area.
     pub encounter_method: NamedApiResource<EncounterMethod>,
@@ -56,6 +59,7 @@ pub struct EncounterMethodRate {
 
 /// [EncounterVersionDetails official documentation](https://pokeapi.co/docs/v2#encounterversiondetails)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EncounterVersionDetails {
     /// The chance of an encounter to occur.
     pub rate: i64,
@@ -65,6 +69,7 @@ pub struct EncounterVersionDetails {
 
 /// [PokemonEncounter official documentation](https://pokeapi.co/docs/v2#pokemonencounter)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonEncounter {
     /// The Pokémon being encountered.
     pub pokemon: NamedApiResource<Pokemon>,
@@ -74,6 +79,7 @@ pub struct PokemonEncounter {
 
 /// [PalParkArea official documentation](https://pokeapi.co/docs/v2#palparkarea)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PalParkArea {
     /// The identifier for this resource.
     pub id: i64,
@@ -87,6 +93,7 @@ pub struct PalParkArea {
 
 /// [PalParkEncounterSpecies official documentation](https://pokeapi.co/docs/v2#palparkencounterspecies)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PalParkEncounterSpecies {
     /// The base score given to the player when this Pokémon is caught during a pal park run.
     pub base_score: i64,
@@ -98,6 +105,7 @@ pub struct PalParkEncounterSpecies {
 
 /// [Region official documentation](https://pokeapi.co/docs/v2#region)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Region {
     /// The identifier for this resource.
     pub id: i64,

--- a/src/model/machines.rs
+++ b/src/model/machines.rs
@@ -4,6 +4,7 @@ use super::{games::VersionGroup, items::Item, moves::Move, resource::NamedApiRes
 
 /// [Machine official documentation](https://pokeapi.co/docs/v2#machine)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Machine {
     /// The identifier for this resource.
     pub id: i64,

--- a/src/model/moves.rs
+++ b/src/model/moves.rs
@@ -12,6 +12,7 @@ use super::{
 
 /// [Move official documentation](https://pokeapi.co/docs/v2#move)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Move {
     /// The identifier for this resource.
     pub id: i64,
@@ -67,6 +68,7 @@ pub struct Move {
 
 /// [ContestComboSets official documentation](https://pokeapi.co/docs/v2#contestcombosets)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ContestComboSets {
     /// A detail of moves this move can be used before or after, granting additional appeal points in contests.
     pub normal: ContestComboDetail,
@@ -77,6 +79,7 @@ pub struct ContestComboSets {
 
 /// [ContestComboDetail official documentation](https://pokeapi.co/docs/v2#contestcombodetail)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ContestComboDetail {
     /// A list of moves to use before this move.
     pub use_before: Option<Vec<NamedApiResource<Move>>>,
@@ -86,6 +89,7 @@ pub struct ContestComboDetail {
 
 /// [MoveFlavorText official documentation](https://pokeapi.co/docs/v2#moveflavortext)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveFlavorText {
     /// The localized flavor text for an api resource in a specific language.
     pub flavor_text: String,
@@ -97,6 +101,7 @@ pub struct MoveFlavorText {
 
 /// [MoveMetaData official documentation](https://pokeapi.co/docs/v2#movemetadata)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveMetaData {
     /// The status ailment this move inflicts on its target.
     pub ailment: NamedApiResource<MoveAilment>,
@@ -126,6 +131,7 @@ pub struct MoveMetaData {
 
 /// [MoveStatChange official documentation](https://pokeapi.co/docs/v2#movestatchange)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveStatChange {
     /// The amount of change.
     pub change: i64,
@@ -135,6 +141,7 @@ pub struct MoveStatChange {
 
 /// [PastMoveStatValues official documentation](https://pokeapi.co/docs/v2#pastmovestatvalues)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PastMoveStatValues {
     /// The percent value of how likely this move is to be successful.
     pub accuracy: Option<i64>,
@@ -155,6 +162,7 @@ pub struct PastMoveStatValues {
 
 /// [MoveAilment official documentation](https://pokeapi.co/docs/v2#moveailment)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveAilment {
     /// The identifier for this resource.
     pub id: i64,
@@ -168,6 +176,7 @@ pub struct MoveAilment {
 
 /// [MoveBattleStyle official documentation](https://pokeapi.co/docs/v2#movebattlestyle)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveBattleStyle {
     /// The identifier for this resource.
     pub id: i64,
@@ -179,6 +188,7 @@ pub struct MoveBattleStyle {
 
 /// [MoveCategory official documentation](https://pokeapi.co/docs/v2#movecategory)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveCategory {
     /// The identifier for this resource.
     pub id: i64,
@@ -192,6 +202,7 @@ pub struct MoveCategory {
 
 /// [MoveDamageClass official documentation](https://pokeapi.co/docs/v2#movedamageclass)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveDamageClass {
     /// The identifier for this resource.
     pub id: i64,
@@ -207,6 +218,7 @@ pub struct MoveDamageClass {
 
 /// [MoveLearnMethod official documentation](https://pokeapi.co/docs/v2#movelearnmethod)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveLearnMethod {
     /// The identifier for this resource.
     pub id: i64,
@@ -222,6 +234,7 @@ pub struct MoveLearnMethod {
 
 /// [MoveTarget official documentation](https://pokeapi.co/docs/v2#movetarget)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveTarget {
     /// The identifier for this resource.
     pub id: i64,

--- a/src/model/pokemon.rs
+++ b/src/model/pokemon.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 /// [Ability official documentation](https://pokeapi.co/docs/v2#ability)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Ability {
     /// The identifier for this resource.
     pub id: i64,
@@ -38,7 +38,7 @@ pub struct Ability {
 }
 
 /// [AbilityEffectChange official documentation](https://pokeapi.co/docs/v2#abilityeffectchange)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct AbilityEffectChange {
     /// The previous effect of this ability listed in different languages.
     pub effect_entries: Vec<Effect>,
@@ -47,7 +47,7 @@ pub struct AbilityEffectChange {
 }
 
 /// [AbilityFlavorText official documentation](https://pokeapi.co/docs/v2#abilityflavortext)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct AbilityFlavorText {
     /// The localized name for an API resource in a specific language.
     pub flavor_text: String,
@@ -58,7 +58,7 @@ pub struct AbilityFlavorText {
 }
 
 /// [AbilityPokemon official documentation](https://pokeapi.co/docs/v2#abilitypokemon)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct AbilityPokemon {
     /// Whether or not this a hidden ability for the referenced Pokémon.
     pub is_hidden: bool,
@@ -70,7 +70,7 @@ pub struct AbilityPokemon {
 }
 
 /// [Characteristic official documentation](https://pokeapi.co/docs/v2#characteristic)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Characteristic {
     /// The identifier for this resource.
     pub id: i64,
@@ -86,7 +86,7 @@ pub struct Characteristic {
 }
 
 /// [EggGroup official documentation](https://pokeapi.co/docs/v2#egggroup)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct EggGroup {
     /// The identifier for this resource.
     pub id: i64,
@@ -99,7 +99,7 @@ pub struct EggGroup {
 }
 
 /// [Gender official documentation](https://pokeapi.co/docs/v2#gender)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Gender {
     /// The identifier for this resource.
     pub id: i64,
@@ -112,7 +112,7 @@ pub struct Gender {
 }
 
 /// [PokemonSpeciesGender official documentation](https://pokeapi.co/docs/v2#pokemonspeciesgender)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonSpeciesGender {
     /// The chance of this Pokémon being female, in eighths; or -1 for genderless.
     pub rate: i64,
@@ -121,7 +121,7 @@ pub struct PokemonSpeciesGender {
 }
 
 /// [GrowthRate official documentation](https://pokeapi.co/docs/v2#growthrate)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GrowthRate {
     /// The identifier for this resource.
     pub id: i64,
@@ -138,7 +138,7 @@ pub struct GrowthRate {
 }
 
 /// [GrowthRateExperienceLevel official documentation](https://pokeapi.co/docs/v2#growthrateexperiencelevel)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GrowthRateExperienceLevel {
     /// The level gained.
     pub level: i64,
@@ -147,7 +147,7 @@ pub struct GrowthRateExperienceLevel {
 }
 
 /// [Nature official documentation](https://pokeapi.co/docs/v2#nature)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Nature {
     /// The identifier for this resource.
     pub id: i64,
@@ -170,7 +170,7 @@ pub struct Nature {
 }
 
 /// [NatureStatChange official documentation](https://pokeapi.co/docs/v2#naturestatchange)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct NatureStatChange {
     /// The amount of change.
     pub max_change: i64,
@@ -179,7 +179,7 @@ pub struct NatureStatChange {
 }
 
 /// [MoveBattleStylePreference official documentation](https://pokeapi.co/docs/v2#movebattlestylepreference)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct MoveBattleStylePreference {
     /// Chance of using the move, in percent, if HP is under one half.
     pub low_hp_preference: i64,
@@ -190,7 +190,7 @@ pub struct MoveBattleStylePreference {
 }
 
 /// [PokeathlonStat official documentation](https://pokeapi.co/docs/v2#pokeathlonstat)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokeathlonStat {
     /// The identifier for this resource.
     pub id: i64,
@@ -203,7 +203,7 @@ pub struct PokeathlonStat {
 }
 
 /// [NaturePokeathlonStatAffectSets official documentation](https://pokeapi.co/docs/v2#naturepokeathlonstataffectsets)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct NaturePokeathlonStatAffectSets {
     /// A list of natures and how they change the referenced Pokéathlon stat.
     pub increase: Vec<NaturePokeathlonStatAffect>,
@@ -212,7 +212,7 @@ pub struct NaturePokeathlonStatAffectSets {
 }
 
 /// [NaturePokeathlonStatAffect official documentation](https://pokeapi.co/docs/v2#naturepokeathlonstataffect)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct NaturePokeathlonStatAffect {
     /// The maximum amount of change to the referenced Pokéathlon stat.
     pub max_change: i64,
@@ -221,7 +221,7 @@ pub struct NaturePokeathlonStatAffect {
 }
 
 /// [Pokemon official documentation](https://pokeapi.co/docs/v2#pokemon)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Pokemon {
     /// The identifier for this resource.
     pub id: i64,
@@ -263,7 +263,7 @@ pub struct Pokemon {
 }
 
 /// [PokemonAbility official documentation](https://pokeapi.co/docs/v2#pokemonability)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonAbility {
     /// Whether or not this is a hidden ability.
     pub is_hidden: bool,
@@ -274,7 +274,7 @@ pub struct PokemonAbility {
 }
 
 /// [PokemonType official documentation](https://pokeapi.co/docs/v2#pokemontype)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonType {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -284,7 +284,7 @@ pub struct PokemonType {
 }
 
 /// [PokemonTypePast official documentation](https://pokeapi.co/docs/v2#pokemontypepast)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonTypePast {
     /// The last generation in which the referenced pokémon had the listed types.
     pub generation: NamedApiResource<Generation>,
@@ -293,7 +293,7 @@ pub struct PokemonTypePast {
 }
 
 /// [PokemonHeldItem official documentation](https://pokeapi.co/docs/v2#pokemonhelditem)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonHeldItem {
     /// The item the referenced Pokémon holds.
     pub item: NamedApiResource<Item>,
@@ -302,7 +302,7 @@ pub struct PokemonHeldItem {
 }
 
 /// [PokemonHeldItemVersion official documentation](https://pokeapi.co/docs/v2#pokemonhelditemversion)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonHeldItemVersion {
     /// The version in which the item is held.
     pub version: NamedApiResource<Version>,
@@ -311,7 +311,7 @@ pub struct PokemonHeldItemVersion {
 }
 
 /// [PokemonMove official documentation](https://pokeapi.co/docs/v2#pokemonmove)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonMove {
     /// The move the Pokémon can learn.
     #[serde(rename = "move")]
@@ -321,7 +321,7 @@ pub struct PokemonMove {
 }
 
 /// [PokemonMoveVersion official documentation](https://pokeapi.co/docs/v2#pokemonmoveversion)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonMoveVersion {
     /// The method by which the move is learned.
     pub move_learn_method: NamedApiResource<MoveLearnMethod>,
@@ -332,7 +332,7 @@ pub struct PokemonMoveVersion {
 }
 
 /// [PokemonStat official documentation](https://pokeapi.co/docs/v2#pokemonstat)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonStat {
     /// The stat the Pokémon has.
     pub stat: NamedApiResource<Stat>,
@@ -343,7 +343,7 @@ pub struct PokemonStat {
 }
 
 /// [PokemonSprites official documentation](https://pokeapi.co/docs/v2#pokemonsprites)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonSprites {
     /// The default depiction of this Pokémon from the front in battle.
     pub front_default: Option<String>,
@@ -368,7 +368,7 @@ pub struct PokemonSprites {
 }
 
 /// References sprites that doesn't come from game.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct OtherSprites {
     /// Dream world sprites of this Pokémon.
     pub dream_world: DreamWorldSprites,
@@ -380,7 +380,7 @@ pub struct OtherSprites {
 }
 
 /// References the dream world sprites of a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct DreamWorldSprites {
     /// The default despiction of this Pokémon from dream world.
     pub front_default: Option<String>,
@@ -389,7 +389,7 @@ pub struct DreamWorldSprites {
 }
 
 /// References the home sprites of a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct HomeSprites {
     /// The default despiction of this Pokémon from dream world.
     pub front_default: Option<String>,
@@ -402,14 +402,14 @@ pub struct HomeSprites {
 }
 
 /// References the official artwork of a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct OfficialArtworkSprites {
     /// The default despiction of this Pokémon form the official artwork.
     pub front_default: Option<String>,
 }
 
 /// Sprites of a Pokémon, per generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct VersionsSprites {
     /// Sprites for the first generation.
     #[serde(rename = "generation-i")]
@@ -438,7 +438,7 @@ pub struct VersionsSprites {
 }
 
 /// Sprites for the first generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationISprites {
     /// Sprites for Pokémon Red & Pokémon Blue.
     #[serde(rename = "red-blue")]
@@ -448,7 +448,7 @@ pub struct GenerationISprites {
 }
 
 /// Sprites for Pokémon Red & Pokémon Blue.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct RedBlueSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -465,7 +465,7 @@ pub struct RedBlueSprites {
 }
 
 /// Sprites for Pokémon Yellow.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct YellowSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -482,7 +482,7 @@ pub struct YellowSprites {
 }
 
 /// Sprites for the second generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationIISprites {
     /// Sprites for Pokémon Crystal.
     pub crystal: CrystalSprites,
@@ -493,7 +493,7 @@ pub struct GenerationIISprites {
 }
 
 /// Sprites for Pokémon Crystal.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct CrystalSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -514,7 +514,7 @@ pub struct CrystalSprites {
 }
 
 /// Sprites for Pokémon Gold.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GoldSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -529,7 +529,7 @@ pub struct GoldSprites {
 }
 
 /// Sprites for Pokémon Silver.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct SilverSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -544,7 +544,7 @@ pub struct SilverSprites {
 }
 
 /// Sprites for the third generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationIIISprites {
     /// Sprites for Pokémon Emerald.
     pub emerald: EmeraldSprites,
@@ -557,7 +557,7 @@ pub struct GenerationIIISprites {
 }
 
 /// Sprites for Pokémon Emerald.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct EmeraldSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -566,7 +566,7 @@ pub struct EmeraldSprites {
 }
 
 /// Sprites for Pokémon FireRed & Pokémon LeafGreen.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct FireredLeafgreenSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -579,7 +579,7 @@ pub struct FireredLeafgreenSprites {
 }
 
 /// Sprites for Pokémon Ruby & Pokémon Sapphire.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct RubySapphireSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -592,7 +592,7 @@ pub struct RubySapphireSprites {
 }
 
 /// Sprites for the fourth generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationIVSprites {
     /// Sprites for Pokémon Diamond & Pokémon Pearl.
     #[serde(rename = "diamond-pearl")]
@@ -605,7 +605,7 @@ pub struct GenerationIVSprites {
 }
 
 /// Sprites for Pokémon Diamond & Pokémon Pearl.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct DiamondPearlSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -626,7 +626,7 @@ pub struct DiamondPearlSprites {
 }
 
 /// Sprites for Pokémon Platinum.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PlatinumSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -647,7 +647,7 @@ pub struct PlatinumSprites {
 }
 
 /// Sprites for Pokémon HeartGold & Pokémon SoulSilver.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct HeartgoldSoulsilverSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -668,7 +668,7 @@ pub struct HeartgoldSoulsilverSprites {
 }
 
 /// Sprites for the fifth generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationVSprites {
     /// Sprites for Pokémon Black & Pokémon White.
     #[serde(rename = "black-white")]
@@ -676,7 +676,7 @@ pub struct GenerationVSprites {
 }
 
 /// Sprites for Pokémon Black & Pokémon White.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct BlackWhiteSprites {
     /// The animated sprites for a Pokémon.
     pub animated: BlackWhiteAnimatedSprites,
@@ -699,7 +699,7 @@ pub struct BlackWhiteSprites {
 }
 
 /// The animated sprites for a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct BlackWhiteAnimatedSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -720,7 +720,7 @@ pub struct BlackWhiteAnimatedSprites {
 }
 
 /// Sprites for the sixth generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationVISprites {
     /// Sprites for Pokémon OmegaRuby & Pokémon AlphaSapphire.
     #[serde(rename = "omegaruby-alphasapphire")]
@@ -731,7 +731,7 @@ pub struct GenerationVISprites {
 }
 
 /// Sprites for Pokémon OmegaRuby & Pokémon AlphaSapphire.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct OmegarubyAlphasapphireSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -744,7 +744,7 @@ pub struct OmegarubyAlphasapphireSprites {
 }
 
 /// Sprites for Pokémon X & Pokémon Y.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct XYSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -757,7 +757,7 @@ pub struct XYSprites {
 }
 
 /// Sprites for the seventh generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationVIISprites {
     /// The icons sprites of a Pokémon.
     pub icons: IconsSprites,
@@ -767,7 +767,7 @@ pub struct GenerationVIISprites {
 }
 
 /// The icons sprites of a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct IconsSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -776,7 +776,7 @@ pub struct IconsSprites {
 }
 
 /// Sprites for Pokémon UltraSun & Pokémon UltraMoon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct UltrasunUltramoonSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -789,14 +789,14 @@ pub struct UltrasunUltramoonSprites {
 }
 
 /// Sprites for the eighth generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationVIIISprites {
     /// The icons sprites of a Pokémon.
     pub icons: IconsSprites,
 }
 
 /// [LocationAreaEncounter official documentation](https://pokeapi.co/docs/v2#locationareaencounter)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct LocationAreaEncounter {
     /// The location area the referenced Pokémon can be encountered in.
     pub location_area: NamedApiResource<LocationArea>,
@@ -805,7 +805,7 @@ pub struct LocationAreaEncounter {
 }
 
 /// [PokemonColor official documentation](https://pokeapi.co/docs/v2#pokemoncolor)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonColor {
     /// The identifier for this resource.
     pub id: i64,
@@ -818,7 +818,7 @@ pub struct PokemonColor {
 }
 
 /// [PokemonForm official documentation](https://pokeapi.co/docs/v2#pokemonform)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonForm {
     /// The identifier for this resource.
     pub id: i64,
@@ -852,7 +852,7 @@ pub struct PokemonForm {
 }
 
 /// [PokemonFormType official documentation](https://pokeapi.co/docs/v2#pokemonformtype)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonFormType {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -862,7 +862,7 @@ pub struct PokemonFormType {
 }
 
 /// [PokemonFormSprites official documentation](https://pokeapi.co/docs/v2#pokemonformsprites)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonFormSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -883,7 +883,7 @@ pub struct PokemonFormSprites {
 }
 
 /// [PokemonHabitat official documentation](https://pokeapi.co/docs/v2#pokemonhabitat)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonHabitat {
     /// The identifier for this resource.
     pub id: i64,
@@ -896,7 +896,7 @@ pub struct PokemonHabitat {
 }
 
 /// [PokemonShape official documentation](https://pokeapi.co/docs/v2#pokemonshape)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonShape {
     /// The identifier for this resource.
     pub id: i64,
@@ -911,7 +911,7 @@ pub struct PokemonShape {
 }
 
 /// [AwesomeName official documentation](https://pokeapi.co/docs/v2#awesomename)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct AwesomeName {
     /// The localized "scientific" name for an API resource in a specific language.
     pub awesome_name: String,
@@ -920,7 +920,7 @@ pub struct AwesomeName {
 }
 
 /// [PokemonSpecies official documentation](https://pokeapi.co/docs/v2#pokemonspecies)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonSpecies {
     /// The identifier for this resource.
     pub id: i64,
@@ -981,7 +981,7 @@ pub struct PokemonSpecies {
 }
 
 /// [Genus official documentation](https://pokeapi.co/docs/v2#genus)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Genus {
     /// The localized genus for the referenced Pokémon species.
     pub genus: String,
@@ -990,7 +990,7 @@ pub struct Genus {
 }
 
 /// [PokemonSpeciesDexEntry official documentation](https://pokeapi.co/docs/v2#pokemonspeciesdexentry)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonSpeciesDexEntry {
     /// The index number within the Pokédex.
     pub entry_number: i64,
@@ -999,7 +999,7 @@ pub struct PokemonSpeciesDexEntry {
 }
 
 /// [PalParkEncounterArea official documentation](https://pokeapi.co/docs/v2#palparkencounterarea)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PalParkEncounterArea {
     /// The base score given to the player when the referenced Pokémon is caught during a pal park run.
     pub base_score: i64,
@@ -1010,7 +1010,7 @@ pub struct PalParkEncounterArea {
 }
 
 /// [PokemonSpeciesVariety official documentation](https://pokeapi.co/docs/v2#pokemonspeciesvariety)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct PokemonSpeciesVariety {
     /// Whether this variety is the default variety.
     pub is_default: bool,
@@ -1019,7 +1019,7 @@ pub struct PokemonSpeciesVariety {
 }
 
 /// [Stat official documentation](https://pokeapi.co/docs/v2#stat)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Stat {
     /// The identifier for this resource.
     pub id: i64,
@@ -1042,7 +1042,7 @@ pub struct Stat {
 }
 
 /// [MoveStatAffectSets official documentation](https://pokeapi.co/docs/v2#movestataffectsets)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct MoveStatAffectSets {
     /// A list of moves and how they change the referenced stat.
     pub increase: Vec<MoveStatAffect>,
@@ -1051,7 +1051,7 @@ pub struct MoveStatAffectSets {
 }
 
 /// [MoveStatAffect official documentation](https://pokeapi.co/docs/v2#movestataffect)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct MoveStatAffect {
     /// The maximum amount of change to the referenced stat.
     pub change: i64,
@@ -1061,7 +1061,7 @@ pub struct MoveStatAffect {
 }
 
 /// [NatureStatAffectSets official documentation](https://pokeapi.co/docs/v2#naturestataffectsets)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct NatureStatAffectSets {
     /// A list of natures and how they change the referenced stat.
     pub increase: Vec<NamedApiResource<Nature>>,
@@ -1070,7 +1070,7 @@ pub struct NatureStatAffectSets {
 }
 
 /// [Type official documentation](https://pokeapi.co/docs/v2#type)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Type {
     /// The identifier for this resource.
     pub id: i64,
@@ -1095,7 +1095,7 @@ pub struct Type {
 }
 
 /// [TypePokemon official documentation](https://pokeapi.co/docs/v2#typepokemon)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct TypePokemon {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -1104,7 +1104,7 @@ pub struct TypePokemon {
 }
 
 /// [TypeRelations official documentation](https://pokeapi.co/docs/v2#typerelations)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct TypeRelations {
     /// A list of types this type has no effect on.
     pub no_damage_to: Vec<NamedApiResource<Type>>,
@@ -1121,7 +1121,7 @@ pub struct TypeRelations {
 }
 
 /// [TypeRelationsPast official documentation](https://pokeapi.co/docs/v2#typerelationspast)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct TypeRelationsPast {
     /// The last generation in which the referenced type had the listed damage relations.
     pub generation: NamedApiResource<Generation>,

--- a/src/model/pokemon.rs
+++ b/src/model/pokemon.rs
@@ -16,7 +16,7 @@ use super::{
 
 /// [Ability official documentation](https://pokeapi.co/docs/v2#ability)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Ability {
     /// The identifier for this resource.
     pub id: i64,
@@ -40,7 +40,7 @@ pub struct Ability {
 
 /// [AbilityEffectChange official documentation](https://pokeapi.co/docs/v2#abilityeffectchange)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct AbilityEffectChange {
     /// The previous effect of this ability listed in different languages.
     pub effect_entries: Vec<Effect>,
@@ -50,7 +50,7 @@ pub struct AbilityEffectChange {
 
 /// [AbilityFlavorText official documentation](https://pokeapi.co/docs/v2#abilityflavortext)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct AbilityFlavorText {
     /// The localized name for an API resource in a specific language.
     pub flavor_text: String,
@@ -62,7 +62,7 @@ pub struct AbilityFlavorText {
 
 /// [AbilityPokemon official documentation](https://pokeapi.co/docs/v2#abilitypokemon)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct AbilityPokemon {
     /// Whether or not this a hidden ability for the referenced Pokémon.
     pub is_hidden: bool,
@@ -75,7 +75,7 @@ pub struct AbilityPokemon {
 
 /// [Characteristic official documentation](https://pokeapi.co/docs/v2#characteristic)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Characteristic {
     /// The identifier for this resource.
     pub id: i64,
@@ -92,7 +92,7 @@ pub struct Characteristic {
 
 /// [EggGroup official documentation](https://pokeapi.co/docs/v2#egggroup)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EggGroup {
     /// The identifier for this resource.
     pub id: i64,
@@ -106,7 +106,7 @@ pub struct EggGroup {
 
 /// [Gender official documentation](https://pokeapi.co/docs/v2#gender)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Gender {
     /// The identifier for this resource.
     pub id: i64,
@@ -120,7 +120,7 @@ pub struct Gender {
 
 /// [PokemonSpeciesGender official documentation](https://pokeapi.co/docs/v2#pokemonspeciesgender)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonSpeciesGender {
     /// The chance of this Pokémon being female, in eighths; or -1 for genderless.
     pub rate: i64,
@@ -130,7 +130,7 @@ pub struct PokemonSpeciesGender {
 
 /// [GrowthRate official documentation](https://pokeapi.co/docs/v2#growthrate)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GrowthRate {
     /// The identifier for this resource.
     pub id: i64,
@@ -148,7 +148,7 @@ pub struct GrowthRate {
 
 /// [GrowthRateExperienceLevel official documentation](https://pokeapi.co/docs/v2#growthrateexperiencelevel)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GrowthRateExperienceLevel {
     /// The level gained.
     pub level: i64,
@@ -158,7 +158,7 @@ pub struct GrowthRateExperienceLevel {
 
 /// [Nature official documentation](https://pokeapi.co/docs/v2#nature)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Nature {
     /// The identifier for this resource.
     pub id: i64,
@@ -182,7 +182,7 @@ pub struct Nature {
 
 /// [NatureStatChange official documentation](https://pokeapi.co/docs/v2#naturestatchange)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct NatureStatChange {
     /// The amount of change.
     pub max_change: i64,
@@ -192,7 +192,7 @@ pub struct NatureStatChange {
 
 /// [MoveBattleStylePreference official documentation](https://pokeapi.co/docs/v2#movebattlestylepreference)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveBattleStylePreference {
     /// Chance of using the move, in percent, if HP is under one half.
     pub low_hp_preference: i64,
@@ -204,7 +204,7 @@ pub struct MoveBattleStylePreference {
 
 /// [PokeathlonStat official documentation](https://pokeapi.co/docs/v2#pokeathlonstat)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokeathlonStat {
     /// The identifier for this resource.
     pub id: i64,
@@ -218,7 +218,7 @@ pub struct PokeathlonStat {
 
 /// [NaturePokeathlonStatAffectSets official documentation](https://pokeapi.co/docs/v2#naturepokeathlonstataffectsets)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct NaturePokeathlonStatAffectSets {
     /// A list of natures and how they change the referenced Pokéathlon stat.
     pub increase: Vec<NaturePokeathlonStatAffect>,
@@ -228,7 +228,7 @@ pub struct NaturePokeathlonStatAffectSets {
 
 /// [NaturePokeathlonStatAffect official documentation](https://pokeapi.co/docs/v2#naturepokeathlonstataffect)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct NaturePokeathlonStatAffect {
     /// The maximum amount of change to the referenced Pokéathlon stat.
     pub max_change: i64,
@@ -238,7 +238,7 @@ pub struct NaturePokeathlonStatAffect {
 
 /// [Pokemon official documentation](https://pokeapi.co/docs/v2#pokemon)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Pokemon {
     /// The identifier for this resource.
     pub id: i64,
@@ -281,7 +281,7 @@ pub struct Pokemon {
 
 /// [PokemonAbility official documentation](https://pokeapi.co/docs/v2#pokemonability)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonAbility {
     /// Whether or not this is a hidden ability.
     pub is_hidden: bool,
@@ -293,7 +293,7 @@ pub struct PokemonAbility {
 
 /// [PokemonType official documentation](https://pokeapi.co/docs/v2#pokemontype)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonType {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -304,7 +304,7 @@ pub struct PokemonType {
 
 /// [PokemonTypePast official documentation](https://pokeapi.co/docs/v2#pokemontypepast)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonTypePast {
     /// The last generation in which the referenced pokémon had the listed types.
     pub generation: NamedApiResource<Generation>,
@@ -314,7 +314,7 @@ pub struct PokemonTypePast {
 
 /// [PokemonHeldItem official documentation](https://pokeapi.co/docs/v2#pokemonhelditem)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonHeldItem {
     /// The item the referenced Pokémon holds.
     pub item: NamedApiResource<Item>,
@@ -324,7 +324,7 @@ pub struct PokemonHeldItem {
 
 /// [PokemonHeldItemVersion official documentation](https://pokeapi.co/docs/v2#pokemonhelditemversion)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonHeldItemVersion {
     /// The version in which the item is held.
     pub version: NamedApiResource<Version>,
@@ -334,7 +334,7 @@ pub struct PokemonHeldItemVersion {
 
 /// [PokemonMove official documentation](https://pokeapi.co/docs/v2#pokemonmove)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonMove {
     /// The move the Pokémon can learn.
     #[serde(rename = "move")]
@@ -345,7 +345,7 @@ pub struct PokemonMove {
 
 /// [PokemonMoveVersion official documentation](https://pokeapi.co/docs/v2#pokemonmoveversion)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonMoveVersion {
     /// The method by which the move is learned.
     pub move_learn_method: NamedApiResource<MoveLearnMethod>,
@@ -357,7 +357,7 @@ pub struct PokemonMoveVersion {
 
 /// [PokemonStat official documentation](https://pokeapi.co/docs/v2#pokemonstat)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonStat {
     /// The stat the Pokémon has.
     pub stat: NamedApiResource<Stat>,
@@ -369,7 +369,7 @@ pub struct PokemonStat {
 
 /// [PokemonSprites official documentation](https://pokeapi.co/docs/v2#pokemonsprites)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonSprites {
     /// The default depiction of this Pokémon from the front in battle.
     pub front_default: Option<String>,
@@ -395,7 +395,7 @@ pub struct PokemonSprites {
 
 /// References sprites that doesn't come from game.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct OtherSprites {
     /// Dream world sprites of this Pokémon.
     pub dream_world: DreamWorldSprites,
@@ -408,7 +408,7 @@ pub struct OtherSprites {
 
 /// References the dream world sprites of a Pokémon.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct DreamWorldSprites {
     /// The default despiction of this Pokémon from dream world.
     pub front_default: Option<String>,
@@ -418,7 +418,7 @@ pub struct DreamWorldSprites {
 
 /// References the home sprites of a Pokémon.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct HomeSprites {
     /// The default despiction of this Pokémon from dream world.
     pub front_default: Option<String>,
@@ -432,7 +432,7 @@ pub struct HomeSprites {
 
 /// References the official artwork of a Pokémon.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct OfficialArtworkSprites {
     /// The default despiction of this Pokémon form the official artwork.
     pub front_default: Option<String>,
@@ -440,7 +440,7 @@ pub struct OfficialArtworkSprites {
 
 /// Sprites of a Pokémon, per generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct VersionsSprites {
     /// Sprites for the first generation.
     #[serde(rename = "generation-i")]
@@ -470,7 +470,7 @@ pub struct VersionsSprites {
 
 /// Sprites for the first generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationISprites {
     /// Sprites for Pokémon Red & Pokémon Blue.
     #[serde(rename = "red-blue")]
@@ -481,7 +481,7 @@ pub struct GenerationISprites {
 
 /// Sprites for Pokémon Red & Pokémon Blue.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct RedBlueSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -499,7 +499,7 @@ pub struct RedBlueSprites {
 
 /// Sprites for Pokémon Yellow.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct YellowSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -517,7 +517,7 @@ pub struct YellowSprites {
 
 /// Sprites for the second generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationIISprites {
     /// Sprites for Pokémon Crystal.
     pub crystal: CrystalSprites,
@@ -529,7 +529,7 @@ pub struct GenerationIISprites {
 
 /// Sprites for Pokémon Crystal.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct CrystalSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -551,7 +551,7 @@ pub struct CrystalSprites {
 
 /// Sprites for Pokémon Gold.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GoldSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -567,7 +567,7 @@ pub struct GoldSprites {
 
 /// Sprites for Pokémon Silver.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct SilverSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -583,7 +583,7 @@ pub struct SilverSprites {
 
 /// Sprites for the third generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationIIISprites {
     /// Sprites for Pokémon Emerald.
     pub emerald: EmeraldSprites,
@@ -597,7 +597,7 @@ pub struct GenerationIIISprites {
 
 /// Sprites for Pokémon Emerald.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct EmeraldSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -607,7 +607,7 @@ pub struct EmeraldSprites {
 
 /// Sprites for Pokémon FireRed & Pokémon LeafGreen.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct FireredLeafgreenSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -621,7 +621,7 @@ pub struct FireredLeafgreenSprites {
 
 /// Sprites for Pokémon Ruby & Pokémon Sapphire.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct RubySapphireSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -635,7 +635,7 @@ pub struct RubySapphireSprites {
 
 /// Sprites for the fourth generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationIVSprites {
     /// Sprites for Pokémon Diamond & Pokémon Pearl.
     #[serde(rename = "diamond-pearl")]
@@ -649,7 +649,7 @@ pub struct GenerationIVSprites {
 
 /// Sprites for Pokémon Diamond & Pokémon Pearl.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct DiamondPearlSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -671,7 +671,7 @@ pub struct DiamondPearlSprites {
 
 /// Sprites for Pokémon Platinum.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PlatinumSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -693,7 +693,7 @@ pub struct PlatinumSprites {
 
 /// Sprites for Pokémon HeartGold & Pokémon SoulSilver.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct HeartgoldSoulsilverSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -715,7 +715,7 @@ pub struct HeartgoldSoulsilverSprites {
 
 /// Sprites for the fifth generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationVSprites {
     /// Sprites for Pokémon Black & Pokémon White.
     #[serde(rename = "black-white")]
@@ -724,7 +724,7 @@ pub struct GenerationVSprites {
 
 /// Sprites for Pokémon Black & Pokémon White.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct BlackWhiteSprites {
     /// The animated sprites for a Pokémon.
     pub animated: BlackWhiteAnimatedSprites,
@@ -748,7 +748,7 @@ pub struct BlackWhiteSprites {
 
 /// The animated sprites for a Pokémon.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct BlackWhiteAnimatedSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -770,7 +770,7 @@ pub struct BlackWhiteAnimatedSprites {
 
 /// Sprites for the sixth generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationVISprites {
     /// Sprites for Pokémon OmegaRuby & Pokémon AlphaSapphire.
     #[serde(rename = "omegaruby-alphasapphire")]
@@ -782,7 +782,7 @@ pub struct GenerationVISprites {
 
 /// Sprites for Pokémon OmegaRuby & Pokémon AlphaSapphire.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct OmegarubyAlphasapphireSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -796,7 +796,7 @@ pub struct OmegarubyAlphasapphireSprites {
 
 /// Sprites for Pokémon X & Pokémon Y.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct XYSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -810,7 +810,7 @@ pub struct XYSprites {
 
 /// Sprites for the seventh generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationVIISprites {
     /// The icons sprites of a Pokémon.
     pub icons: IconsSprites,
@@ -821,7 +821,7 @@ pub struct GenerationVIISprites {
 
 /// The icons sprites of a Pokémon.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct IconsSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -831,7 +831,7 @@ pub struct IconsSprites {
 
 /// Sprites for Pokémon UltraSun & Pokémon UltraMoon.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct UltrasunUltramoonSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -845,7 +845,7 @@ pub struct UltrasunUltramoonSprites {
 
 /// Sprites for the eighth generation.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationVIIISprites {
     /// The icons sprites of a Pokémon.
     pub icons: IconsSprites,
@@ -853,7 +853,7 @@ pub struct GenerationVIIISprites {
 
 /// [LocationAreaEncounter official documentation](https://pokeapi.co/docs/v2#locationareaencounter)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct LocationAreaEncounter {
     /// The location area the referenced Pokémon can be encountered in.
     pub location_area: NamedApiResource<LocationArea>,
@@ -863,7 +863,7 @@ pub struct LocationAreaEncounter {
 
 /// [PokemonColor official documentation](https://pokeapi.co/docs/v2#pokemoncolor)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonColor {
     /// The identifier for this resource.
     pub id: i64,
@@ -877,7 +877,7 @@ pub struct PokemonColor {
 
 /// [PokemonForm official documentation](https://pokeapi.co/docs/v2#pokemonform)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonForm {
     /// The identifier for this resource.
     pub id: i64,
@@ -912,7 +912,7 @@ pub struct PokemonForm {
 
 /// [PokemonFormType official documentation](https://pokeapi.co/docs/v2#pokemonformtype)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonFormType {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -923,7 +923,7 @@ pub struct PokemonFormType {
 
 /// [PokemonFormSprites official documentation](https://pokeapi.co/docs/v2#pokemonformsprites)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonFormSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -945,7 +945,7 @@ pub struct PokemonFormSprites {
 
 /// [PokemonHabitat official documentation](https://pokeapi.co/docs/v2#pokemonhabitat)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonHabitat {
     /// The identifier for this resource.
     pub id: i64,
@@ -959,7 +959,7 @@ pub struct PokemonHabitat {
 
 /// [PokemonShape official documentation](https://pokeapi.co/docs/v2#pokemonshape)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonShape {
     /// The identifier for this resource.
     pub id: i64,
@@ -975,7 +975,7 @@ pub struct PokemonShape {
 
 /// [AwesomeName official documentation](https://pokeapi.co/docs/v2#awesomename)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct AwesomeName {
     /// The localized "scientific" name for an API resource in a specific language.
     pub awesome_name: String,
@@ -985,7 +985,7 @@ pub struct AwesomeName {
 
 /// [PokemonSpecies official documentation](https://pokeapi.co/docs/v2#pokemonspecies)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonSpecies {
     /// The identifier for this resource.
     pub id: i64,
@@ -1047,7 +1047,7 @@ pub struct PokemonSpecies {
 
 /// [Genus official documentation](https://pokeapi.co/docs/v2#genus)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Genus {
     /// The localized genus for the referenced Pokémon species.
     pub genus: String,
@@ -1057,7 +1057,7 @@ pub struct Genus {
 
 /// [PokemonSpeciesDexEntry official documentation](https://pokeapi.co/docs/v2#pokemonspeciesdexentry)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonSpeciesDexEntry {
     /// The index number within the Pokédex.
     pub entry_number: i64,
@@ -1067,7 +1067,7 @@ pub struct PokemonSpeciesDexEntry {
 
 /// [PalParkEncounterArea official documentation](https://pokeapi.co/docs/v2#palparkencounterarea)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PalParkEncounterArea {
     /// The base score given to the player when the referenced Pokémon is caught during a pal park run.
     pub base_score: i64,
@@ -1079,7 +1079,7 @@ pub struct PalParkEncounterArea {
 
 /// [PokemonSpeciesVariety official documentation](https://pokeapi.co/docs/v2#pokemonspeciesvariety)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct PokemonSpeciesVariety {
     /// Whether this variety is the default variety.
     pub is_default: bool,
@@ -1089,7 +1089,7 @@ pub struct PokemonSpeciesVariety {
 
 /// [Stat official documentation](https://pokeapi.co/docs/v2#stat)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Stat {
     /// The identifier for this resource.
     pub id: i64,
@@ -1113,7 +1113,7 @@ pub struct Stat {
 
 /// [MoveStatAffectSets official documentation](https://pokeapi.co/docs/v2#movestataffectsets)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveStatAffectSets {
     /// A list of moves and how they change the referenced stat.
     pub increase: Vec<MoveStatAffect>,
@@ -1123,7 +1123,7 @@ pub struct MoveStatAffectSets {
 
 /// [MoveStatAffect official documentation](https://pokeapi.co/docs/v2#movestataffect)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MoveStatAffect {
     /// The maximum amount of change to the referenced stat.
     pub change: i64,
@@ -1134,7 +1134,7 @@ pub struct MoveStatAffect {
 
 /// [NatureStatAffectSets official documentation](https://pokeapi.co/docs/v2#naturestataffectsets)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct NatureStatAffectSets {
     /// A list of natures and how they change the referenced stat.
     pub increase: Vec<NamedApiResource<Nature>>,
@@ -1144,7 +1144,7 @@ pub struct NatureStatAffectSets {
 
 /// [Type official documentation](https://pokeapi.co/docs/v2#type)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Type {
     /// The identifier for this resource.
     pub id: i64,
@@ -1170,7 +1170,7 @@ pub struct Type {
 
 /// [TypePokemon official documentation](https://pokeapi.co/docs/v2#typepokemon)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct TypePokemon {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -1180,7 +1180,7 @@ pub struct TypePokemon {
 
 /// [TypeRelations official documentation](https://pokeapi.co/docs/v2#typerelations)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct TypeRelations {
     /// A list of types this type has no effect on.
     pub no_damage_to: Vec<NamedApiResource<Type>>,
@@ -1198,7 +1198,7 @@ pub struct TypeRelations {
 
 /// [TypeRelationsPast official documentation](https://pokeapi.co/docs/v2#typerelationspast)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct TypeRelationsPast {
     /// The last generation in which the referenced type had the listed damage relations.
     pub generation: NamedApiResource<Generation>,

--- a/src/model/pokemon.rs
+++ b/src/model/pokemon.rs
@@ -15,7 +15,8 @@ use super::{
 };
 
 /// [Ability official documentation](https://pokeapi.co/docs/v2#ability)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Ability {
     /// The identifier for this resource.
     pub id: i64,
@@ -38,7 +39,8 @@ pub struct Ability {
 }
 
 /// [AbilityEffectChange official documentation](https://pokeapi.co/docs/v2#abilityeffectchange)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct AbilityEffectChange {
     /// The previous effect of this ability listed in different languages.
     pub effect_entries: Vec<Effect>,
@@ -47,7 +49,8 @@ pub struct AbilityEffectChange {
 }
 
 /// [AbilityFlavorText official documentation](https://pokeapi.co/docs/v2#abilityflavortext)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct AbilityFlavorText {
     /// The localized name for an API resource in a specific language.
     pub flavor_text: String,
@@ -58,7 +61,8 @@ pub struct AbilityFlavorText {
 }
 
 /// [AbilityPokemon official documentation](https://pokeapi.co/docs/v2#abilitypokemon)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct AbilityPokemon {
     /// Whether or not this a hidden ability for the referenced Pokémon.
     pub is_hidden: bool,
@@ -70,7 +74,8 @@ pub struct AbilityPokemon {
 }
 
 /// [Characteristic official documentation](https://pokeapi.co/docs/v2#characteristic)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Characteristic {
     /// The identifier for this resource.
     pub id: i64,
@@ -86,7 +91,8 @@ pub struct Characteristic {
 }
 
 /// [EggGroup official documentation](https://pokeapi.co/docs/v2#egggroup)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct EggGroup {
     /// The identifier for this resource.
     pub id: i64,
@@ -99,7 +105,8 @@ pub struct EggGroup {
 }
 
 /// [Gender official documentation](https://pokeapi.co/docs/v2#gender)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Gender {
     /// The identifier for this resource.
     pub id: i64,
@@ -112,7 +119,8 @@ pub struct Gender {
 }
 
 /// [PokemonSpeciesGender official documentation](https://pokeapi.co/docs/v2#pokemonspeciesgender)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonSpeciesGender {
     /// The chance of this Pokémon being female, in eighths; or -1 for genderless.
     pub rate: i64,
@@ -121,7 +129,8 @@ pub struct PokemonSpeciesGender {
 }
 
 /// [GrowthRate official documentation](https://pokeapi.co/docs/v2#growthrate)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GrowthRate {
     /// The identifier for this resource.
     pub id: i64,
@@ -138,7 +147,8 @@ pub struct GrowthRate {
 }
 
 /// [GrowthRateExperienceLevel official documentation](https://pokeapi.co/docs/v2#growthrateexperiencelevel)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GrowthRateExperienceLevel {
     /// The level gained.
     pub level: i64,
@@ -147,7 +157,8 @@ pub struct GrowthRateExperienceLevel {
 }
 
 /// [Nature official documentation](https://pokeapi.co/docs/v2#nature)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Nature {
     /// The identifier for this resource.
     pub id: i64,
@@ -170,7 +181,8 @@ pub struct Nature {
 }
 
 /// [NatureStatChange official documentation](https://pokeapi.co/docs/v2#naturestatchange)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct NatureStatChange {
     /// The amount of change.
     pub max_change: i64,
@@ -179,7 +191,8 @@ pub struct NatureStatChange {
 }
 
 /// [MoveBattleStylePreference official documentation](https://pokeapi.co/docs/v2#movebattlestylepreference)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct MoveBattleStylePreference {
     /// Chance of using the move, in percent, if HP is under one half.
     pub low_hp_preference: i64,
@@ -190,7 +203,8 @@ pub struct MoveBattleStylePreference {
 }
 
 /// [PokeathlonStat official documentation](https://pokeapi.co/docs/v2#pokeathlonstat)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokeathlonStat {
     /// The identifier for this resource.
     pub id: i64,
@@ -203,7 +217,8 @@ pub struct PokeathlonStat {
 }
 
 /// [NaturePokeathlonStatAffectSets official documentation](https://pokeapi.co/docs/v2#naturepokeathlonstataffectsets)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct NaturePokeathlonStatAffectSets {
     /// A list of natures and how they change the referenced Pokéathlon stat.
     pub increase: Vec<NaturePokeathlonStatAffect>,
@@ -212,7 +227,8 @@ pub struct NaturePokeathlonStatAffectSets {
 }
 
 /// [NaturePokeathlonStatAffect official documentation](https://pokeapi.co/docs/v2#naturepokeathlonstataffect)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct NaturePokeathlonStatAffect {
     /// The maximum amount of change to the referenced Pokéathlon stat.
     pub max_change: i64,
@@ -221,7 +237,8 @@ pub struct NaturePokeathlonStatAffect {
 }
 
 /// [Pokemon official documentation](https://pokeapi.co/docs/v2#pokemon)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Pokemon {
     /// The identifier for this resource.
     pub id: i64,
@@ -263,7 +280,8 @@ pub struct Pokemon {
 }
 
 /// [PokemonAbility official documentation](https://pokeapi.co/docs/v2#pokemonability)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonAbility {
     /// Whether or not this is a hidden ability.
     pub is_hidden: bool,
@@ -274,7 +292,8 @@ pub struct PokemonAbility {
 }
 
 /// [PokemonType official documentation](https://pokeapi.co/docs/v2#pokemontype)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonType {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -284,7 +303,8 @@ pub struct PokemonType {
 }
 
 /// [PokemonTypePast official documentation](https://pokeapi.co/docs/v2#pokemontypepast)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonTypePast {
     /// The last generation in which the referenced pokémon had the listed types.
     pub generation: NamedApiResource<Generation>,
@@ -293,7 +313,8 @@ pub struct PokemonTypePast {
 }
 
 /// [PokemonHeldItem official documentation](https://pokeapi.co/docs/v2#pokemonhelditem)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonHeldItem {
     /// The item the referenced Pokémon holds.
     pub item: NamedApiResource<Item>,
@@ -302,7 +323,8 @@ pub struct PokemonHeldItem {
 }
 
 /// [PokemonHeldItemVersion official documentation](https://pokeapi.co/docs/v2#pokemonhelditemversion)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonHeldItemVersion {
     /// The version in which the item is held.
     pub version: NamedApiResource<Version>,
@@ -311,7 +333,8 @@ pub struct PokemonHeldItemVersion {
 }
 
 /// [PokemonMove official documentation](https://pokeapi.co/docs/v2#pokemonmove)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonMove {
     /// The move the Pokémon can learn.
     #[serde(rename = "move")]
@@ -321,7 +344,8 @@ pub struct PokemonMove {
 }
 
 /// [PokemonMoveVersion official documentation](https://pokeapi.co/docs/v2#pokemonmoveversion)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonMoveVersion {
     /// The method by which the move is learned.
     pub move_learn_method: NamedApiResource<MoveLearnMethod>,
@@ -332,7 +356,8 @@ pub struct PokemonMoveVersion {
 }
 
 /// [PokemonStat official documentation](https://pokeapi.co/docs/v2#pokemonstat)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonStat {
     /// The stat the Pokémon has.
     pub stat: NamedApiResource<Stat>,
@@ -343,7 +368,8 @@ pub struct PokemonStat {
 }
 
 /// [PokemonSprites official documentation](https://pokeapi.co/docs/v2#pokemonsprites)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonSprites {
     /// The default depiction of this Pokémon from the front in battle.
     pub front_default: Option<String>,
@@ -368,7 +394,8 @@ pub struct PokemonSprites {
 }
 
 /// References sprites that doesn't come from game.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct OtherSprites {
     /// Dream world sprites of this Pokémon.
     pub dream_world: DreamWorldSprites,
@@ -380,7 +407,8 @@ pub struct OtherSprites {
 }
 
 /// References the dream world sprites of a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct DreamWorldSprites {
     /// The default despiction of this Pokémon from dream world.
     pub front_default: Option<String>,
@@ -389,7 +417,8 @@ pub struct DreamWorldSprites {
 }
 
 /// References the home sprites of a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct HomeSprites {
     /// The default despiction of this Pokémon from dream world.
     pub front_default: Option<String>,
@@ -402,14 +431,16 @@ pub struct HomeSprites {
 }
 
 /// References the official artwork of a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct OfficialArtworkSprites {
     /// The default despiction of this Pokémon form the official artwork.
     pub front_default: Option<String>,
 }
 
 /// Sprites of a Pokémon, per generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct VersionsSprites {
     /// Sprites for the first generation.
     #[serde(rename = "generation-i")]
@@ -438,7 +469,8 @@ pub struct VersionsSprites {
 }
 
 /// Sprites for the first generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationISprites {
     /// Sprites for Pokémon Red & Pokémon Blue.
     #[serde(rename = "red-blue")]
@@ -448,7 +480,8 @@ pub struct GenerationISprites {
 }
 
 /// Sprites for Pokémon Red & Pokémon Blue.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct RedBlueSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -465,7 +498,8 @@ pub struct RedBlueSprites {
 }
 
 /// Sprites for Pokémon Yellow.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct YellowSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -482,7 +516,8 @@ pub struct YellowSprites {
 }
 
 /// Sprites for the second generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationIISprites {
     /// Sprites for Pokémon Crystal.
     pub crystal: CrystalSprites,
@@ -493,7 +528,8 @@ pub struct GenerationIISprites {
 }
 
 /// Sprites for Pokémon Crystal.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct CrystalSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -514,7 +550,8 @@ pub struct CrystalSprites {
 }
 
 /// Sprites for Pokémon Gold.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GoldSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -529,7 +566,8 @@ pub struct GoldSprites {
 }
 
 /// Sprites for Pokémon Silver.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct SilverSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -544,7 +582,8 @@ pub struct SilverSprites {
 }
 
 /// Sprites for the third generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationIIISprites {
     /// Sprites for Pokémon Emerald.
     pub emerald: EmeraldSprites,
@@ -557,7 +596,8 @@ pub struct GenerationIIISprites {
 }
 
 /// Sprites for Pokémon Emerald.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct EmeraldSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -566,7 +606,8 @@ pub struct EmeraldSprites {
 }
 
 /// Sprites for Pokémon FireRed & Pokémon LeafGreen.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct FireredLeafgreenSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -579,7 +620,8 @@ pub struct FireredLeafgreenSprites {
 }
 
 /// Sprites for Pokémon Ruby & Pokémon Sapphire.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct RubySapphireSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -592,7 +634,8 @@ pub struct RubySapphireSprites {
 }
 
 /// Sprites for the fourth generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationIVSprites {
     /// Sprites for Pokémon Diamond & Pokémon Pearl.
     #[serde(rename = "diamond-pearl")]
@@ -605,7 +648,8 @@ pub struct GenerationIVSprites {
 }
 
 /// Sprites for Pokémon Diamond & Pokémon Pearl.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct DiamondPearlSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -626,7 +670,8 @@ pub struct DiamondPearlSprites {
 }
 
 /// Sprites for Pokémon Platinum.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PlatinumSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -647,7 +692,8 @@ pub struct PlatinumSprites {
 }
 
 /// Sprites for Pokémon HeartGold & Pokémon SoulSilver.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct HeartgoldSoulsilverSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -668,7 +714,8 @@ pub struct HeartgoldSoulsilverSprites {
 }
 
 /// Sprites for the fifth generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationVSprites {
     /// Sprites for Pokémon Black & Pokémon White.
     #[serde(rename = "black-white")]
@@ -676,7 +723,8 @@ pub struct GenerationVSprites {
 }
 
 /// Sprites for Pokémon Black & Pokémon White.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct BlackWhiteSprites {
     /// The animated sprites for a Pokémon.
     pub animated: BlackWhiteAnimatedSprites,
@@ -699,7 +747,8 @@ pub struct BlackWhiteSprites {
 }
 
 /// The animated sprites for a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct BlackWhiteAnimatedSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -720,7 +769,8 @@ pub struct BlackWhiteAnimatedSprites {
 }
 
 /// Sprites for the sixth generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationVISprites {
     /// Sprites for Pokémon OmegaRuby & Pokémon AlphaSapphire.
     #[serde(rename = "omegaruby-alphasapphire")]
@@ -731,7 +781,8 @@ pub struct GenerationVISprites {
 }
 
 /// Sprites for Pokémon OmegaRuby & Pokémon AlphaSapphire.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct OmegarubyAlphasapphireSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -744,7 +795,8 @@ pub struct OmegarubyAlphasapphireSprites {
 }
 
 /// Sprites for Pokémon X & Pokémon Y.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct XYSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -757,7 +809,8 @@ pub struct XYSprites {
 }
 
 /// Sprites for the seventh generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationVIISprites {
     /// The icons sprites of a Pokémon.
     pub icons: IconsSprites,
@@ -767,7 +820,8 @@ pub struct GenerationVIISprites {
 }
 
 /// The icons sprites of a Pokémon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct IconsSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -776,7 +830,8 @@ pub struct IconsSprites {
 }
 
 /// Sprites for Pokémon UltraSun & Pokémon UltraMoon.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct UltrasunUltramoonSprites {
     /// The default front sprite of a Pokémon.
     pub front_default: Option<String>,
@@ -789,14 +844,16 @@ pub struct UltrasunUltramoonSprites {
 }
 
 /// Sprites for the eighth generation.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationVIIISprites {
     /// The icons sprites of a Pokémon.
     pub icons: IconsSprites,
 }
 
 /// [LocationAreaEncounter official documentation](https://pokeapi.co/docs/v2#locationareaencounter)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct LocationAreaEncounter {
     /// The location area the referenced Pokémon can be encountered in.
     pub location_area: NamedApiResource<LocationArea>,
@@ -805,7 +862,8 @@ pub struct LocationAreaEncounter {
 }
 
 /// [PokemonColor official documentation](https://pokeapi.co/docs/v2#pokemoncolor)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonColor {
     /// The identifier for this resource.
     pub id: i64,
@@ -818,7 +876,8 @@ pub struct PokemonColor {
 }
 
 /// [PokemonForm official documentation](https://pokeapi.co/docs/v2#pokemonform)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonForm {
     /// The identifier for this resource.
     pub id: i64,
@@ -852,7 +911,8 @@ pub struct PokemonForm {
 }
 
 /// [PokemonFormType official documentation](https://pokeapi.co/docs/v2#pokemonformtype)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonFormType {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -862,7 +922,8 @@ pub struct PokemonFormType {
 }
 
 /// [PokemonFormSprites official documentation](https://pokeapi.co/docs/v2#pokemonformsprites)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonFormSprites {
     /// The default back sprite of a Pokémon.
     pub back_default: Option<String>,
@@ -883,7 +944,8 @@ pub struct PokemonFormSprites {
 }
 
 /// [PokemonHabitat official documentation](https://pokeapi.co/docs/v2#pokemonhabitat)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonHabitat {
     /// The identifier for this resource.
     pub id: i64,
@@ -896,7 +958,8 @@ pub struct PokemonHabitat {
 }
 
 /// [PokemonShape official documentation](https://pokeapi.co/docs/v2#pokemonshape)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonShape {
     /// The identifier for this resource.
     pub id: i64,
@@ -911,7 +974,8 @@ pub struct PokemonShape {
 }
 
 /// [AwesomeName official documentation](https://pokeapi.co/docs/v2#awesomename)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct AwesomeName {
     /// The localized "scientific" name for an API resource in a specific language.
     pub awesome_name: String,
@@ -920,7 +984,8 @@ pub struct AwesomeName {
 }
 
 /// [PokemonSpecies official documentation](https://pokeapi.co/docs/v2#pokemonspecies)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonSpecies {
     /// The identifier for this resource.
     pub id: i64,
@@ -981,7 +1046,8 @@ pub struct PokemonSpecies {
 }
 
 /// [Genus official documentation](https://pokeapi.co/docs/v2#genus)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Genus {
     /// The localized genus for the referenced Pokémon species.
     pub genus: String,
@@ -990,7 +1056,8 @@ pub struct Genus {
 }
 
 /// [PokemonSpeciesDexEntry official documentation](https://pokeapi.co/docs/v2#pokemonspeciesdexentry)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonSpeciesDexEntry {
     /// The index number within the Pokédex.
     pub entry_number: i64,
@@ -999,7 +1066,8 @@ pub struct PokemonSpeciesDexEntry {
 }
 
 /// [PalParkEncounterArea official documentation](https://pokeapi.co/docs/v2#palparkencounterarea)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PalParkEncounterArea {
     /// The base score given to the player when the referenced Pokémon is caught during a pal park run.
     pub base_score: i64,
@@ -1010,7 +1078,8 @@ pub struct PalParkEncounterArea {
 }
 
 /// [PokemonSpeciesVariety official documentation](https://pokeapi.co/docs/v2#pokemonspeciesvariety)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct PokemonSpeciesVariety {
     /// Whether this variety is the default variety.
     pub is_default: bool,
@@ -1019,7 +1088,8 @@ pub struct PokemonSpeciesVariety {
 }
 
 /// [Stat official documentation](https://pokeapi.co/docs/v2#stat)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Stat {
     /// The identifier for this resource.
     pub id: i64,
@@ -1042,7 +1112,8 @@ pub struct Stat {
 }
 
 /// [MoveStatAffectSets official documentation](https://pokeapi.co/docs/v2#movestataffectsets)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct MoveStatAffectSets {
     /// A list of moves and how they change the referenced stat.
     pub increase: Vec<MoveStatAffect>,
@@ -1051,7 +1122,8 @@ pub struct MoveStatAffectSets {
 }
 
 /// [MoveStatAffect official documentation](https://pokeapi.co/docs/v2#movestataffect)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct MoveStatAffect {
     /// The maximum amount of change to the referenced stat.
     pub change: i64,
@@ -1061,7 +1133,8 @@ pub struct MoveStatAffect {
 }
 
 /// [NatureStatAffectSets official documentation](https://pokeapi.co/docs/v2#naturestataffectsets)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct NatureStatAffectSets {
     /// A list of natures and how they change the referenced stat.
     pub increase: Vec<NamedApiResource<Nature>>,
@@ -1070,7 +1143,8 @@ pub struct NatureStatAffectSets {
 }
 
 /// [Type official documentation](https://pokeapi.co/docs/v2#type)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Type {
     /// The identifier for this resource.
     pub id: i64,
@@ -1095,7 +1169,8 @@ pub struct Type {
 }
 
 /// [TypePokemon official documentation](https://pokeapi.co/docs/v2#typepokemon)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct TypePokemon {
     /// The order the Pokémon's types are listed in.
     pub slot: i64,
@@ -1104,7 +1179,8 @@ pub struct TypePokemon {
 }
 
 /// [TypeRelations official documentation](https://pokeapi.co/docs/v2#typerelations)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct TypeRelations {
     /// A list of types this type has no effect on.
     pub no_damage_to: Vec<NamedApiResource<Type>>,
@@ -1121,7 +1197,8 @@ pub struct TypeRelations {
 }
 
 /// [TypeRelationsPast official documentation](https://pokeapi.co/docs/v2#typerelationspast)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct TypeRelationsPast {
     /// The last generation in which the referenced type had the listed damage relations.
     pub generation: NamedApiResource<Generation>,

--- a/src/model/resource.rs
+++ b/src/model/resource.rs
@@ -10,7 +10,8 @@ use super::{
 };
 
 /// [NamedApiResourceList official documentation](https:///pokeapi.co/docs/v2#namedapiresourcelist)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct NamedApiResourceList<T> {
     /// The total number of resources available from this API.
     pub count: i64,
@@ -23,7 +24,8 @@ pub struct NamedApiResourceList<T> {
 }
 
 /// [ApiResource official documentation](https://pokeapi.co/docs/v2#apiresource)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct ApiResource<T> {
     /// The URL of the referenced resource.
     pub url: String,
@@ -32,7 +34,8 @@ pub struct ApiResource<T> {
 }
 
 /// [Description official documentation](https://pokeapi.co/docs/v2#description)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Description {
     /// The localized description for an API resource in a specific language.
     pub description: String,
@@ -41,7 +44,8 @@ pub struct Description {
 }
 
 /// [Effect official documentation](https://pokeapi.co/docs/v2#effect)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Effect {
     /// The localized effect text for an API resource in a specific language.
     pub effect: String,
@@ -50,7 +54,8 @@ pub struct Effect {
 }
 
 /// [Encounter official documentation](https://pokeapi.co/docs/v2#encounter)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Encounter {
     /// The lowest level the Pokémon could be encountered at.
     pub min_level: i64,
@@ -65,7 +70,8 @@ pub struct Encounter {
 }
 
 /// [FlavorText official documentation](https://pokeapi.co/docs/v2#flavortext)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct FlavorText {
     /// The localized flavor text for an API resource in a specific language.
     pub flavor_text: String,
@@ -76,7 +82,8 @@ pub struct FlavorText {
 }
 
 /// [GenerationGameIndex official documentation](https://pokeapi.co/docs/v2#generationgameindex)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct GenerationGameIndex {
     /// The internal id of an API resource within game data.
     pub game_index: i64,
@@ -85,7 +92,8 @@ pub struct GenerationGameIndex {
 }
 
 /// [MachineVersionDetail official documentation](https://pokeapi.co/docs/v2#machineversiondetail)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct MachineVersionDetail {
     /// The machine that teaches a move from an item.
     pub machine: ApiResource<Machine>,
@@ -94,7 +102,8 @@ pub struct MachineVersionDetail {
 }
 
 /// [Name official documentation](https://pokeapi.co/docs/v2#name)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct Name {
     /// The localized name for an API resource in a specific language.
     pub name: String,
@@ -103,7 +112,8 @@ pub struct Name {
 }
 
 /// [VerboseEffect official documentation](https://pokeapi.co/docs/v2#verboseeffect)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct VerboseEffect {
     /// The localized effect text for an API resource in a specific language.
     pub effect: String,
@@ -114,7 +124,8 @@ pub struct VerboseEffect {
 }
 
 /// [VersionEncounterDetail official documentation](https://pokeapi.co/docs/v2#versionencounterdetail)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct VersionEncounterDetail {
     /// The game version this encounter happens in.
     pub version: NamedApiResource<Version>,
@@ -125,7 +136,8 @@ pub struct VersionEncounterDetail {
 }
 
 /// [VersionGameIndex official documentation](https://pokeapi.co/docs/v2#versiongameindex)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct VersionGameIndex {
     /// The internal id of an API resource within game data.
     pub game_index: i64,
@@ -134,7 +146,8 @@ pub struct VersionGameIndex {
 }
 
 /// [VersionGroupFlavorText official documentation](https://pokeapi.co/docs/v2#versiongroupflavortext)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct VersionGroupFlavorText {
     /// The localized name for an API resource in a specific language.
     pub text: String,
@@ -145,7 +158,8 @@ pub struct VersionGroupFlavorText {
 }
 
 /// [NamedApiResource official documentation](https://pokeapi.co/docs/v2#namedapiresource)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(serialize, derive(serde::Serialize))]
 pub struct NamedApiResource<T> {
     /// The name of the referenced resource.
     pub name: String,

--- a/src/model/resource.rs
+++ b/src/model/resource.rs
@@ -11,7 +11,7 @@ use super::{
 
 /// [NamedApiResourceList official documentation](https:///pokeapi.co/docs/v2#namedapiresourcelist)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct NamedApiResourceList<T> {
     /// The total number of resources available from this API.
     pub count: i64,
@@ -25,7 +25,7 @@ pub struct NamedApiResourceList<T> {
 
 /// [ApiResource official documentation](https://pokeapi.co/docs/v2#apiresource)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ApiResource<T> {
     /// The URL of the referenced resource.
     pub url: String,
@@ -35,7 +35,7 @@ pub struct ApiResource<T> {
 
 /// [Description official documentation](https://pokeapi.co/docs/v2#description)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Description {
     /// The localized description for an API resource in a specific language.
     pub description: String,
@@ -45,7 +45,7 @@ pub struct Description {
 
 /// [Effect official documentation](https://pokeapi.co/docs/v2#effect)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Effect {
     /// The localized effect text for an API resource in a specific language.
     pub effect: String,
@@ -55,7 +55,7 @@ pub struct Effect {
 
 /// [Encounter official documentation](https://pokeapi.co/docs/v2#encounter)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Encounter {
     /// The lowest level the Pokémon could be encountered at.
     pub min_level: i64,
@@ -71,7 +71,7 @@ pub struct Encounter {
 
 /// [FlavorText official documentation](https://pokeapi.co/docs/v2#flavortext)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct FlavorText {
     /// The localized flavor text for an API resource in a specific language.
     pub flavor_text: String,
@@ -83,7 +83,7 @@ pub struct FlavorText {
 
 /// [GenerationGameIndex official documentation](https://pokeapi.co/docs/v2#generationgameindex)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GenerationGameIndex {
     /// The internal id of an API resource within game data.
     pub game_index: i64,
@@ -93,7 +93,7 @@ pub struct GenerationGameIndex {
 
 /// [MachineVersionDetail official documentation](https://pokeapi.co/docs/v2#machineversiondetail)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MachineVersionDetail {
     /// The machine that teaches a move from an item.
     pub machine: ApiResource<Machine>,
@@ -103,7 +103,7 @@ pub struct MachineVersionDetail {
 
 /// [Name official documentation](https://pokeapi.co/docs/v2#name)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Name {
     /// The localized name for an API resource in a specific language.
     pub name: String,
@@ -113,7 +113,7 @@ pub struct Name {
 
 /// [VerboseEffect official documentation](https://pokeapi.co/docs/v2#verboseeffect)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct VerboseEffect {
     /// The localized effect text for an API resource in a specific language.
     pub effect: String,
@@ -125,7 +125,7 @@ pub struct VerboseEffect {
 
 /// [VersionEncounterDetail official documentation](https://pokeapi.co/docs/v2#versionencounterdetail)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct VersionEncounterDetail {
     /// The game version this encounter happens in.
     pub version: NamedApiResource<Version>,
@@ -137,7 +137,7 @@ pub struct VersionEncounterDetail {
 
 /// [VersionGameIndex official documentation](https://pokeapi.co/docs/v2#versiongameindex)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct VersionGameIndex {
     /// The internal id of an API resource within game data.
     pub game_index: i64,
@@ -147,7 +147,7 @@ pub struct VersionGameIndex {
 
 /// [VersionGroupFlavorText official documentation](https://pokeapi.co/docs/v2#versiongroupflavortext)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct VersionGroupFlavorText {
     /// The localized name for an API resource in a specific language.
     pub text: String,
@@ -159,7 +159,7 @@ pub struct VersionGroupFlavorText {
 
 /// [NamedApiResource official documentation](https://pokeapi.co/docs/v2#namedapiresource)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(serialize, derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct NamedApiResource<T> {
     /// The name of the referenced resource.
     pub name: String,

--- a/src/model/resource.rs
+++ b/src/model/resource.rs
@@ -10,7 +10,7 @@ use super::{
 };
 
 /// [NamedApiResourceList official documentation](https:///pokeapi.co/docs/v2#namedapiresourcelist)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct NamedApiResourceList<T> {
     /// The total number of resources available from this API.
     pub count: i64,
@@ -23,7 +23,7 @@ pub struct NamedApiResourceList<T> {
 }
 
 /// [ApiResource official documentation](https://pokeapi.co/docs/v2#apiresource)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct ApiResource<T> {
     /// The URL of the referenced resource.
     pub url: String,
@@ -32,7 +32,7 @@ pub struct ApiResource<T> {
 }
 
 /// [Description official documentation](https://pokeapi.co/docs/v2#description)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Description {
     /// The localized description for an API resource in a specific language.
     pub description: String,
@@ -41,7 +41,7 @@ pub struct Description {
 }
 
 /// [Effect official documentation](https://pokeapi.co/docs/v2#effect)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Effect {
     /// The localized effect text for an API resource in a specific language.
     pub effect: String,
@@ -50,7 +50,7 @@ pub struct Effect {
 }
 
 /// [Encounter official documentation](https://pokeapi.co/docs/v2#encounter)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Encounter {
     /// The lowest level the Pokémon could be encountered at.
     pub min_level: i64,
@@ -65,7 +65,7 @@ pub struct Encounter {
 }
 
 /// [FlavorText official documentation](https://pokeapi.co/docs/v2#flavortext)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct FlavorText {
     /// The localized flavor text for an API resource in a specific language.
     pub flavor_text: String,
@@ -76,7 +76,7 @@ pub struct FlavorText {
 }
 
 /// [GenerationGameIndex official documentation](https://pokeapi.co/docs/v2#generationgameindex)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct GenerationGameIndex {
     /// The internal id of an API resource within game data.
     pub game_index: i64,
@@ -85,7 +85,7 @@ pub struct GenerationGameIndex {
 }
 
 /// [MachineVersionDetail official documentation](https://pokeapi.co/docs/v2#machineversiondetail)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct MachineVersionDetail {
     /// The machine that teaches a move from an item.
     pub machine: ApiResource<Machine>,
@@ -94,7 +94,7 @@ pub struct MachineVersionDetail {
 }
 
 /// [Name official documentation](https://pokeapi.co/docs/v2#name)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Name {
     /// The localized name for an API resource in a specific language.
     pub name: String,
@@ -103,7 +103,7 @@ pub struct Name {
 }
 
 /// [VerboseEffect official documentation](https://pokeapi.co/docs/v2#verboseeffect)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct VerboseEffect {
     /// The localized effect text for an API resource in a specific language.
     pub effect: String,
@@ -114,7 +114,7 @@ pub struct VerboseEffect {
 }
 
 /// [VersionEncounterDetail official documentation](https://pokeapi.co/docs/v2#versionencounterdetail)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct VersionEncounterDetail {
     /// The game version this encounter happens in.
     pub version: NamedApiResource<Version>,
@@ -125,7 +125,7 @@ pub struct VersionEncounterDetail {
 }
 
 /// [VersionGameIndex official documentation](https://pokeapi.co/docs/v2#versiongameindex)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct VersionGameIndex {
     /// The internal id of an API resource within game data.
     pub game_index: i64,
@@ -134,7 +134,7 @@ pub struct VersionGameIndex {
 }
 
 /// [VersionGroupFlavorText official documentation](https://pokeapi.co/docs/v2#versiongroupflavortext)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct VersionGroupFlavorText {
     /// The localized name for an API resource in a specific language.
     pub text: String,
@@ -145,7 +145,7 @@ pub struct VersionGroupFlavorText {
 }
 
 /// [NamedApiResource official documentation](https://pokeapi.co/docs/v2#namedapiresource)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct NamedApiResource<T> {
     /// The name of the referenced resource.
     pub name: String,

--- a/src/model/utility.rs
+++ b/src/model/utility.rs
@@ -4,6 +4,7 @@ use super::resource::Name;
 
 /// [Language official documentation](https://pokeapi.co/docs/v2#language)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Language {
     /// The identifier for this resource.
     pub id: i64,


### PR DESCRIPTION
minor change, but could `serde::Serialize` be included with all PokeAPI structs?  I'd like to be able to export the data I retrieve from the library to other tooling/libraries