### PR TITLE
Fix unnamed endpoints

### DIFF
--- a/examples/get_all_pokemon_species_names.rs
+++ b/examples/get_all_pokemon_species_names.rs
@@ -5,7 +5,10 @@ async fn main() {
     let species = rustemon::pokemon::pokemon_species::get_all_entries(&rustemon_client)
         .await
         .unwrap();
-    let species_names: Vec<String> = species.into_iter().map(|species| species.name).collect();
+    let species_names: Vec<String> = species
+        .into_iter()
+        .map(|species| species.name.unwrap())
+        .collect();
 
     println!("All Pokémon species names: {:?}", species_names);
 }

--- a/examples/get_all_pokemon_species_names.rs
+++ b/examples/get_all_pokemon_species_names.rs
@@ -5,10 +5,7 @@ async fn main() {
     let species = rustemon::pokemon::pokemon_species::get_all_entries(&rustemon_client)
         .await
         .unwrap();
-    let species_names: Vec<String> = species
-        .into_iter()
-        .map(|species| species.name.unwrap())
-        .collect();
+    let species_names: Vec<String> = species.into_iter().map(|species| species.name).collect();
 
     println!("All Pokémon species names: {:?}", species_names);
 }

--- a/examples/get_all_unnamed_endpoints.rs
+++ b/examples/get_all_unnamed_endpoints.rs
@@ -1,0 +1,37 @@
+#[tokio::main]
+async fn main() {
+    // Gets all entries from all unnamed endpoints.
+    let rustemon_client = rustemon::client::RustemonClient::default();
+    let characteristics = rustemon::pokemon::characteristic::get_all_entries(&rustemon_client)
+        .await
+        .unwrap();
+    let characteristic = rustemon::pokemon::characteristic::get_by_id(1, &rustemon_client)
+        .await
+        .unwrap();
+    let evolution_chains = rustemon::evolution::evolution_chain::get_all_entries(&rustemon_client)
+        .await
+        .unwrap();
+    let evolution_chain = rustemon::evolution::evolution_chain::get_by_id(1, &rustemon_client)
+        .await
+        .unwrap();
+    let machines = rustemon::machines::machine::get_all_entries(&rustemon_client)
+        .await
+        .unwrap();
+    let machine = rustemon::machines::machine::get_by_id(1, &rustemon_client)
+        .await
+        .unwrap();
+    let contest_effects = rustemon::contests::contest_effect::get_all_entries(&rustemon_client)
+        .await
+        .unwrap();
+    let contest_effect = rustemon::contests::contest_effect::get_by_id(1, &rustemon_client)
+        .await
+        .unwrap();
+    let super_contest_effects =
+        rustemon::contests::super_contest_effect::get_all_entries(&rustemon_client)
+            .await
+            .unwrap();
+    let super_contest_effect =
+        rustemon::contests::super_contest_effect::get_by_id(1, &rustemon_client)
+            .await
+            .unwrap();
+}

--- a/examples/get_all_unnamed_endpoints.rs
+++ b/examples/get_all_unnamed_endpoints.rs
@@ -2,36 +2,35 @@
 async fn main() {
     // Gets all entries from all unnamed endpoints.
     let rustemon_client = rustemon::client::RustemonClient::default();
-    let characteristics = rustemon::pokemon::characteristic::get_all_entries(&rustemon_client)
+
+    rustemon::pokemon::characteristic::get_all_entries(&rustemon_client)
         .await
         .unwrap();
-    let characteristic = rustemon::pokemon::characteristic::get_by_id(1, &rustemon_client)
+    rustemon::pokemon::characteristic::get_by_id(1, &rustemon_client)
         .await
         .unwrap();
-    let evolution_chains = rustemon::evolution::evolution_chain::get_all_entries(&rustemon_client)
+    rustemon::evolution::evolution_chain::get_all_entries(&rustemon_client)
         .await
         .unwrap();
-    let evolution_chain = rustemon::evolution::evolution_chain::get_by_id(1, &rustemon_client)
+    rustemon::evolution::evolution_chain::get_by_id(1, &rustemon_client)
         .await
         .unwrap();
-    let machines = rustemon::machines::machine::get_all_entries(&rustemon_client)
+    rustemon::machines::machine::get_all_entries(&rustemon_client)
         .await
         .unwrap();
-    let machine = rustemon::machines::machine::get_by_id(1, &rustemon_client)
+    rustemon::machines::machine::get_by_id(1, &rustemon_client)
         .await
         .unwrap();
-    let contest_effects = rustemon::contests::contest_effect::get_all_entries(&rustemon_client)
+    rustemon::contests::contest_effect::get_all_entries(&rustemon_client)
         .await
         .unwrap();
-    let contest_effect = rustemon::contests::contest_effect::get_by_id(1, &rustemon_client)
+    rustemon::contests::contest_effect::get_by_id(1, &rustemon_client)
         .await
         .unwrap();
-    let super_contest_effects =
-        rustemon::contests::super_contest_effect::get_all_entries(&rustemon_client)
-            .await
-            .unwrap();
-    let super_contest_effect =
-        rustemon::contests::super_contest_effect::get_by_id(1, &rustemon_client)
-            .await
-            .unwrap();
+    rustemon::contests::super_contest_effect::get_all_entries(&rustemon_client)
+        .await
+        .unwrap();
+    rustemon::contests::super_contest_effect::get_by_id(1, &rustemon_client)
+        .await
+        .unwrap();
 }

--- a/src/contests.rs
+++ b/src/contests.rs
@@ -8,10 +8,10 @@ pub mod contest_type {
 
 /// Contest effects refer to the effects of moves when used in contests.
 pub mod contest_effect {
-    crate::endpoint!(crate::model::contests::ContestEffect; for "contest-effect");
+    crate::endpoint!(unnamed crate::model::contests::ContestEffect; for "contest-effect");
 }
 
 /// Super contest effects refer to the effects of moves when used in super contests.
 pub mod super_contest_effect {
-    crate::endpoint!(crate::model::contests::SuperContestEffect; for "super-contest-effect");
+    crate::endpoint!(unnamed crate::model::contests::SuperContestEffect; for "super-contest-effect");
 }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,6 +1,17 @@
 macro_rules! endpoint {
+    (unnamed $type:ty; for $name:literal) => {
+        use crate::model::resource::{UnnamedApiResourceList, UnnamedApiResource};
+        type ActualApiResourceList<T> = UnnamedApiResourceList<T>;
+        type ActualApiResource<T> = UnnamedApiResource<T>;
+        crate::endpoint!(inner $type; for $name);
+    };
     ($type:ty; for $name:literal) => {
         use crate::model::resource::{NamedApiResourceList, NamedApiResource};
+        type ActualApiResourceList<T> = NamedApiResourceList<T>;
+        type ActualApiResource<T> = NamedApiResource<T>;
+        crate::endpoint!(inner $type; for $name);
+    };
+    (inner $type:ty; for $name:literal) => {
         use crate::client::{RustemonClient, Id};
         use crate::error::Error;
 
@@ -9,8 +20,8 @@ macro_rules! endpoint {
         /// # Arguments
         ///
         /// `rustemon_client` - The [RustemonClient] to use to access the resource.
-        pub async fn get_page(rustemon_client: &RustemonClient) -> Result<NamedApiResourceList<$type>, Error> {
-            rustemon_client.get_by_endpoint::<NamedApiResourceList<$type>>($name).await
+        pub async fn get_page(rustemon_client: &RustemonClient) -> Result<ActualApiResourceList<$type>, Error> {
+            rustemon_client.get_by_endpoint::<ActualApiResourceList<$type>>($name).await
         }
 
         /// Returns the page targeted by the parameters.
@@ -24,8 +35,8 @@ macro_rules! endpoint {
             offset: i64,
             limit: i64,
             rustemon_client: &RustemonClient
-        ) -> Result<NamedApiResourceList<$type>, Error> {
-            rustemon_client.get_with_limit_and_offset::<NamedApiResourceList<$type>>($name, limit, offset).await
+        ) -> Result<ActualApiResourceList<$type>, Error> {
+            rustemon_client.get_with_limit_and_offset::<ActualApiResourceList<$type>>($name, limit, offset).await
         }
 
         /// Returns all entries from the given resource.
@@ -33,7 +44,7 @@ macro_rules! endpoint {
         /// # Arguments
         ///
         /// `rustemon_client` - The [RustemonClient] to use to access the resource.
-        pub async fn get_all_entries(rustemon_client: &RustemonClient) -> Result<Vec<NamedApiResource<$type>>, Error> {
+        pub async fn get_all_entries(rustemon_client: &RustemonClient) -> Result<Vec<ActualApiResource<$type>>, Error> {
             let mut first_page = get_page(rustemon_client).await?;
             let first_page_entries_count = first_page.results.len() as i64;
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,17 +1,21 @@
 macro_rules! endpoint {
     (unnamed $type:ty; for $name:literal) => {
-        use crate::model::resource::{UnnamedApiResourceList, UnnamedApiResource};
-        type ActualApiResourceList<T> = UnnamedApiResourceList<T>;
-        type ActualApiResource<T> = UnnamedApiResource<T>;
-        crate::endpoint!(inner $type; for $name);
+        use crate::model::resource::{ApiResourceList, ApiResource};
+
+        type ResourceList<T> = ApiResourceList<T>;
+        type Resource<T> = ApiResource<T>;
+
+        crate::endpoint!(@inner $type; for $name);
     };
     ($type:ty; for $name:literal) => {
         use crate::model::resource::{NamedApiResourceList, NamedApiResource};
-        type ActualApiResourceList<T> = NamedApiResourceList<T>;
-        type ActualApiResource<T> = NamedApiResource<T>;
-        crate::endpoint!(inner $type; for $name);
+
+        type ResourceList<T> = NamedApiResourceList<T>;
+        type Resource<T> = NamedApiResource<T>;
+
+        crate::endpoint!(@inner $type; for $name);
     };
-    (inner $type:ty; for $name:literal) => {
+    (@inner $type:ty; for $name:literal) => {
         use crate::client::{RustemonClient, Id};
         use crate::error::Error;
 
@@ -20,8 +24,8 @@ macro_rules! endpoint {
         /// # Arguments
         ///
         /// `rustemon_client` - The [RustemonClient] to use to access the resource.
-        pub async fn get_page(rustemon_client: &RustemonClient) -> Result<ActualApiResourceList<$type>, Error> {
-            rustemon_client.get_by_endpoint::<ActualApiResourceList<$type>>($name).await
+        pub async fn get_page(rustemon_client: &RustemonClient) -> Result<ResourceList<$type>, Error> {
+            rustemon_client.get_by_endpoint::<ResourceList<$type>>($name).await
         }
 
         /// Returns the page targeted by the parameters.
@@ -35,8 +39,8 @@ macro_rules! endpoint {
             offset: i64,
             limit: i64,
             rustemon_client: &RustemonClient
-        ) -> Result<ActualApiResourceList<$type>, Error> {
-            rustemon_client.get_with_limit_and_offset::<ActualApiResourceList<$type>>($name, limit, offset).await
+        ) -> Result<ResourceList<$type>, Error> {
+            rustemon_client.get_with_limit_and_offset::<ResourceList<$type>>($name, limit, offset).await
         }
 
         /// Returns all entries from the given resource.
@@ -44,7 +48,7 @@ macro_rules! endpoint {
         /// # Arguments
         ///
         /// `rustemon_client` - The [RustemonClient] to use to access the resource.
-        pub async fn get_all_entries(rustemon_client: &RustemonClient) -> Result<Vec<ActualApiResource<$type>>, Error> {
+        pub async fn get_all_entries(rustemon_client: &RustemonClient) -> Result<Vec<Resource<$type>>, Error> {
             let mut first_page = get_page(rustemon_client).await?;
             let first_page_entries_count = first_page.results.len() as i64;
 

--- a/src/evolution.rs
+++ b/src/evolution.rs
@@ -3,7 +3,7 @@
 /// Evolution chains are essentially family trees. They start with the lowest stage within a family
 /// and detail evolution conditions for each as well as Pokémon they can evolve into up through the hierarchy.
 pub mod evolution_chain {
-    crate::endpoint!(crate::model::evolution::EvolutionChain; for "evolution-chain");
+    crate::endpoint!(unnamed crate::model::evolution::EvolutionChain; for "evolution-chain");
 }
 
 /// Evolution triggers are the events and conditions that cause a Pokémon to evolve.

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -3,5 +3,5 @@
 /// Machines are the representation of items that teach moves to Pokémon. They vary from version to version,
 /// so it is not certain that one specific TM or HM corresponds to a single Machine.
 pub mod machine {
-    crate::endpoint!(crate::model::machines::Machine; for "machine");
+    crate::endpoint!(unnamed crate::model::machines::Machine; for "machine");
 }

--- a/src/model/resource.rs
+++ b/src/model/resource.rs
@@ -9,19 +9,23 @@ use super::{
     utility::Language,
 };
 
-/// [NamedApiResourceList official documentation](https:///pokeapi.co/docs/v2#namedapiresourcelist)
+/// MaybeNamedApiResourceList has no official documentation
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-pub struct NamedApiResourceList<T> {
+pub struct MaybeNamedApiResourceList<R> {
     /// The total number of resources available from this API.
     pub count: i64,
     /// The URL for the next page in the list.
     pub next: Option<String>,
     /// The URL for the previous page in the list.
     pub previous: Option<String>,
-    /// A list of named API resources.
-    pub results: Vec<NamedApiResource<T>>,
+    /// A list of (possibly) named API resources.
+    pub results: Vec<R>,
 }
+/// [NamedApiResourceList official documentation](https:///pokeapi.co/docs/v2#namedapiresourcelist)
+pub type NamedApiResourceList<T> = MaybeNamedApiResourceList<NamedApiResource<T>>;
+/// UnnamedApiResourceList has no official documentation
+pub type UnnamedApiResourceList<T> = MaybeNamedApiResourceList<UnnamedApiResource<T>>;
 
 /// [ApiResource official documentation](https://pokeapi.co/docs/v2#apiresource)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
@@ -162,7 +166,16 @@ pub struct VersionGroupFlavorText {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct NamedApiResource<T> {
     /// The name of the referenced resource.
-    pub name: Option<String>,
+    pub name: String,
+    /// The URL of the referenced resource.
+    pub url: String,
+    #[serde(skip)]
+    _marker: PhantomData<T>,
+}
+/// UnnamedApiResource has no official documentation
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+pub struct UnnamedApiResource<T> {
     /// The URL of the referenced resource.
     pub url: String,
     #[serde(skip)]

--- a/src/model/resource.rs
+++ b/src/model/resource.rs
@@ -162,7 +162,7 @@ pub struct VersionGroupFlavorText {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct NamedApiResource<T> {
     /// The name of the referenced resource.
-    pub name: String,
+    pub name: Option<String>,
     /// The URL of the referenced resource.
     pub url: String,
     #[serde(skip)]

--- a/src/model/resource.rs
+++ b/src/model/resource.rs
@@ -9,23 +9,45 @@ use super::{
     utility::Language,
 };
 
-/// MaybeNamedApiResourceList has no official documentation
+/// [NamedApiResource official documentation](https://pokeapi.co/docs/v2#namedapiresource)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-pub struct MaybeNamedApiResourceList<R> {
+pub struct NamedApiResource<T> {
+    /// The name of the referenced resource.
+    pub name: String,
+    /// The URL of the referenced resource.
+    pub url: String,
+    #[serde(skip)]
+    _marker: PhantomData<T>,
+}
+
+/// [NamedApiResourceList official documentation](https:///pokeapi.co/docs/v2#namedapiresourcelist)
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+pub struct NamedApiResourceList<T> {
     /// The total number of resources available from this API.
     pub count: i64,
     /// The URL for the next page in the list.
     pub next: Option<String>,
     /// The URL for the previous page in the list.
     pub previous: Option<String>,
-    /// A list of (possibly) named API resources.
-    pub results: Vec<R>,
+    /// A list of  named API resources.
+    pub results: Vec<NamedApiResource<T>>,
 }
-/// [NamedApiResourceList official documentation](https:///pokeapi.co/docs/v2#namedapiresourcelist)
-pub type NamedApiResourceList<T> = MaybeNamedApiResourceList<NamedApiResource<T>>;
-/// UnnamedApiResourceList has no official documentation
-pub type UnnamedApiResourceList<T> = MaybeNamedApiResourceList<UnnamedApiResource<T>>;
+
+/// [ApiResourceList official documentation](https:///pokeapi.co/docs/v2#apiresourcelist)
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+pub struct ApiResourceList<T> {
+    /// The total number of resources available from this API.
+    pub count: i64,
+    /// The URL for the next page in the list.
+    pub next: Option<String>,
+    /// The URL for the previous page in the list.
+    pub previous: Option<String>,
+    /// A list of  named API resources.
+    pub results: Vec<ApiResource<T>>,
+}
 
 /// [ApiResource official documentation](https://pokeapi.co/docs/v2#apiresource)
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
@@ -159,25 +181,4 @@ pub struct VersionGroupFlavorText {
     pub language: NamedApiResource<Language>,
     /// The version group which uses this flavor text.
     pub version_group: NamedApiResource<VersionGroup>,
-}
-
-/// [NamedApiResource official documentation](https://pokeapi.co/docs/v2#namedapiresource)
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-pub struct NamedApiResource<T> {
-    /// The name of the referenced resource.
-    pub name: String,
-    /// The URL of the referenced resource.
-    pub url: String,
-    #[serde(skip)]
-    _marker: PhantomData<T>,
-}
-/// UnnamedApiResource has no official documentation
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-pub struct UnnamedApiResource<T> {
-    /// The URL of the referenced resource.
-    pub url: String,
-    #[serde(skip)]
-    _marker: PhantomData<T>,
 }

--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -11,7 +11,7 @@ pub mod ability {
 /// A Pokémon's Characteristic is determined by the remainder of its highest IV divided by 5 (gene_modulo).
 /// Check out [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Characteristic) for greater detail.
 pub mod characteristic {
-    crate::endpoint!(crate::model::pokemon::Characteristic; for "characteristic");
+    crate::endpoint!(unnamed crate::model::pokemon::Characteristic; for "characteristic");
 }
 
 /// Egg Groups are categories which determine which Pokémon are able to interbreed.


### PR DESCRIPTION
This PR:
- Adds a broken example highlighting all [unnamed endpoints](https://pokeapi.co/docs/v2#resource-listspagination-section) (`characteristic`, `contest-effect`, `evolution-chain`, `machine`, and `super-contest-effect`)
- ~Fixes the example above using the third proposed solution in https://github.com/mlemesle/rustemon/issues/38#issuecomment-2646369868~
- Fixes the example above using the *first* solution proposed in https://github.com/mlemesle/rustemon/issues/38#issuecomment-2646369868

Fix #27.
Fix #38.

@mlemesle ~I will eventually employ~ This implements the first solution proposed in https://github.com/mlemesle/rustemon/issues/38#issuecomment-2646369868, just as discussed. ~I just wanted you to see the difference in code, as the first solution requires modifying the `endpoint!` macro, since we need to change the returning type of `get_all_entries`, etc.~

TODO:
- [ ] Remove `get_by_name` accordingly