### PR TITLE
Improve compatibility

### DIFF
--- a/rustemon/Cargo.toml
+++ b/rustemon/Cargo.toml
@@ -13,13 +13,15 @@ repository.workspace = true
 version.workspace = true
 
 [features]
+default = ["cache"]
 serialize = []
 static-resources = ["dep:serde_json"]
+cache = ["dep:http-cache-reqwest", "dep:reqwest-middleware"]
 
 [dependencies]
-http-cache-reqwest = { version = "0.16.0", features = ["manager-moka"] }
+http-cache-reqwest = { version = "0.16.0", features = ["manager-moka"], optional = true }
 reqwest = { version = "0.12.28", default-features = false, features = ["json", "rustls-tls-native-roots"] }
-reqwest-middleware = "0.4.2"
+reqwest-middleware = { version = "0.4.2", optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 thiserror = "2.0.19"
@@ -35,3 +37,11 @@ required-features = ["serialize"]
 [[example]]
 name = "check_static_resources"
 required-features = ["static-resources"]
+
+[[example]]
+name = "custom_filesystem_client"
+required-features = ["cache"]
+
+[[example]]
+name = "custom_in_memory_client"
+required-features = ["cache"]

--- a/rustemon/Cargo.toml
+++ b/rustemon/Cargo.toml
@@ -18,7 +18,7 @@ static-resources = ["dep:serde_json"]
 
 [dependencies]
 http-cache-reqwest = { version = "0.16.0", features = ["manager-moka"] }
-reqwest = { version = "0.12.28", features = ["json"] }
+reqwest = { version = "0.12.28", default-features = false, features = ["json", "rustls-tls"] }
 reqwest-middleware = "0.4.2"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }

--- a/rustemon/Cargo.toml
+++ b/rustemon/Cargo.toml
@@ -18,7 +18,7 @@ static-resources = ["dep:serde_json"]
 
 [dependencies]
 http-cache-reqwest = { version = "0.16.0", features = ["manager-moka"] }
-reqwest = { version = "0.12.28", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.28", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 reqwest-middleware = "0.4.2"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }

--- a/rustemon/README.md
+++ b/rustemon/README.md
@@ -33,6 +33,12 @@ rustemon = { version = "*", features = ["serialize"] }
 
 You can also use the `static-resources` feature, that allow you to easily instanciate models using data statically pulled from the PokeAPI.
 
+The `cache` feature enables caching, and is enabled by default. You can disable it with `default-features = false`:
+
+```toml
+rustemon = { version = "4.6.0", default-features = false }
+```
+
 ##### Models
 
 All the models are located into the following module :
@@ -69,7 +75,7 @@ the library to work.
 ### Caching
 
 All calls to the API are cached by a middleware attached to the [`RustemonClient`](/src/client.rs) you need to instanciate in order
-to make calls to the `PokeAPI`.
+to make calls to the `PokeAPI`. To disable caching, see the Features section above.
 
 ### Examples
 

--- a/rustemon/src/client.rs
+++ b/rustemon/src/client.rs
@@ -151,8 +151,10 @@ impl RustemonClientBuilder {
 /// Custom client used to call Pokeapi.
 #[derive(Debug)]
 pub struct RustemonClient {
-    client: HttpClient,
-    base: Url,
+    /// Inner client.
+    pub client: HttpClient,
+    /// Base URL for the API
+    pub base: Url,
 }
 
 /// Inner representation of an endpoint's id. Used to ease the api calls.

--- a/rustemon/src/client.rs
+++ b/rustemon/src/client.rs
@@ -1,16 +1,25 @@
 //! Defines the client used to access Pokeapi.
 
+#[cfg(feature = "cache")]
 use http_cache_reqwest::{Cache, CacheManager, HttpCache, HttpCacheOptions};
 use reqwest::{Client, IntoUrl, Url};
+#[cfg(feature = "cache")]
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use serde::de::DeserializeOwned;
 
 use crate::error::Error;
 
 // Reexport to ease overloading.
+#[cfg(feature = "cache")]
 pub use http_cache_reqwest::{CacheMode, CacheOptions};
 
+#[cfg(feature = "cache")]
 pub use http_cache_reqwest::{CACacheManager, MokaManager};
+
+#[cfg(feature = "cache")]
+type HttpClient = ClientWithMiddleware;
+#[cfg(not(feature = "cache"))]
+type HttpClient = Client;
 
 /// Environment to target while calling `PokeApi`.
 #[derive(Clone, Default)]
@@ -43,11 +52,20 @@ impl TryFrom<Environment> for Url {
 }
 
 /// Builder used to ease the configuration of `RustemonClient`.
-pub struct RustemonClientBuilder<T: CacheManager> {
+#[cfg(feature = "cache")]
+pub struct RustemonClientBuilder<T: CacheManager = CACacheManager> {
     cache: HttpCache<T>,
     environment: Environment,
 }
 
+/// Builder used to ease the configuration of `RustemonClient`.
+#[cfg(not(feature = "cache"))]
+#[derive(Default)]
+pub struct RustemonClientBuilder {
+    environment: Environment,
+}
+
+#[cfg(feature = "cache")]
 impl Default for RustemonClientBuilder<CACacheManager> {
     fn default() -> Self {
         let manager = CACacheManager::new("./rustemon-cache".into(), false);
@@ -62,6 +80,7 @@ impl Default for RustemonClientBuilder<CACacheManager> {
     }
 }
 
+#[cfg(feature = "cache")]
 impl Default for RustemonClientBuilder<MokaManager> {
     fn default() -> Self {
         Self {
@@ -75,6 +94,7 @@ impl Default for RustemonClientBuilder<MokaManager> {
     }
 }
 
+#[cfg(feature = "cache")]
 impl<T: CacheManager> RustemonClientBuilder<T> {
     /// Configure the `CacheMode` of the builder. See [`CacheMode`].
     pub const fn with_mode(mut self, cache_mode: CacheMode) -> Self {
@@ -111,10 +131,27 @@ impl<T: CacheManager> RustemonClientBuilder<T> {
     }
 }
 
+#[cfg(not(feature = "cache"))]
+impl RustemonClientBuilder {
+    /// Configure the environment of the builder. See [Environment].
+    pub fn with_environment(mut self, environment: Environment) -> Self {
+        self.environment = environment;
+        self
+    }
+
+    /// Consumes the builder in order to create a [`RustemonClient`].
+    pub fn try_build(self) -> Result<RustemonClient, Error> {
+        Ok(RustemonClient {
+            client: Client::new(),
+            base: Url::try_from(self.environment)?,
+        })
+    }
+}
+
 /// Custom client used to call Pokeapi.
 #[derive(Debug)]
 pub struct RustemonClient {
-    client: ClientWithMiddleware,
+    client: HttpClient,
     base: Url,
 }
 
@@ -195,16 +232,24 @@ impl RustemonClient {
 impl Default for RustemonClient {
     /// Returns a `RustemonClient` with default configuration.
     fn default() -> Self {
-        let manager = CACacheManager::new("./rustemon-cache".into(), false);
+        #[cfg(feature = "cache")]
+        let client = {
+            let manager = CACacheManager::new("./rustemon-cache".into(), false);
 
-        Self {
-            client: ClientBuilder::new(Client::new())
+            ClientBuilder::new(Client::new())
                 .with(Cache(HttpCache {
                     mode: CacheMode::Default,
                     manager,
                     options: HttpCacheOptions::default(),
                 }))
-                .build(),
+                .build()
+        };
+
+        #[cfg(not(feature = "cache"))]
+        let client = Client::new();
+
+        Self {
+            client,
             base: Url::try_from(Environment::default()).unwrap(),
         }
     }

--- a/rustemon/src/error.rs
+++ b/rustemon/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
     /// Error coming from `reqwest_middleware`.
+    #[cfg(feature = "cache")]
     #[error(transparent)]
     ReqwestMiddleware(#[from] reqwest_middleware::Error),
     /// Error raised when an Url can't be parsed.


### PR DESCRIPTION
Improve compatibility

`reqwest` 0.12's openssl dependency by default makes it difficult to compile on some targets, so defaulting to `rustls` is better. `reqwest` 0.13 defaults to `rustls`, so upgrading to it would seem to be the best choice, but `http-cache-reqwest` [doesn't have a stable version with 0.13 yet](https://github.com/06chaynes/http-cache/commit/59825cfefdf5f2c66bde2245b5efde990e8a2569).

`http-cache-manager` isn't supported on WASM targets. Added default feature flag `cache` that allows not using cache when disabled.